### PR TITLE
Removes a step to change repo tag.

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,13 +44,8 @@ jobs:
         with:
           repository: "${{ github.repository_owner }}/kubewarden-end-to-end-tests"
           path: "e2e-tests"
+          ref: "v0.2.0"
           fetch-depth: 0
-      - name: "Checkout latest tag"
-        shell: bash
-        run: |
-          cd e2e-tests
-          TAG=$(git describe --tag `git rev-list --tags --max-count=1`)
-          git checkout -B $TAG $TAG
       - name: "Setup bats testing framework"
         uses: mig4/setup-bats@v1.2.0
         with:


### PR DESCRIPTION

## Description

Removes the e2e job step used to checkout repository version and use the "ref" field in the actions/checkout action.
