### PR TITLE
Add monitor mode e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,7 +61,7 @@ jobs:
           policy-server-container-image-artifact: ${{ inputs.policy-server-container-image-artifact }}
       - name: "Run all end-to-end tests"
         run: |
-          make --directory e2e-tests basic-e2e-test
+          make --directory e2e-tests basic-e2e-test reconfiguration-test mutating-requests-test monitor-mode-test
         shell: bash
         env:
           CLUSTER_CONTEXT: k3d-kubewarden-test-cluster #TODO get context from setup-kubewarden-cluster-action

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,6 @@ delete-kubewarden:
 		--kube-context $(CLUSTER_CONTEXT) \
 		delete $(KUBEWARDEN_CRDS_CHART_RELEASE)
 
-
 .PHONY: reconfiguration-test
 reconfiguration-test:
 	$(call bats, $(TESTS_DIR)/reconfiguration-tests.bats)
@@ -90,3 +89,6 @@ basic-e2e-test:
 mutating-requests-test:
 	$(call bats, $(TESTS_DIR)/mutating-requests-tests.bats)
 
+.PHONY: monitor-mode-test
+monitor-mode-test:
+	$(call bats, $(TESTS_DIR)/monitor-mode-tests.bats)

--- a/resources/privileged-pod-policy-monitor.yaml
+++ b/resources/privileged-pod-policy-monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: policies.kubewarden.io/v1alpha2
+kind: ClusterAdmissionPolicy
+metadata:
+  name: privileged-pods
+spec:
+  policyServer: default
+  module: registry://ghcr.io/kubewarden/policies/pod-privileged:v0.1.5
+  mode: monitor
+  rules:
+  - apiGroups: [""]
+    apiVersions: ["v1"]
+    resources: ["pods"]
+    operations:
+    - CREATE
+    - UPDATE
+  mutating: false

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -39,3 +39,19 @@ function wait_for_all_pods_to_be_ready {
 	run kubectl --context $CLUSTER_CONTEXT wait --for=condition=Ready --timeout $TIMEOUT -n kubewarden pod --all
 	[ "$status" -eq 0 ]
 }
+
+function wait_for_default_policy_server_rollout {
+	wait_for_policy_server_rollout default
+}
+
+function wait_for_policy_server_rollout {
+	run kubectl --context $CLUSTER_CONTEXT -n $NAMESPACE rollout status "deployment/policy-server-$1"
+}
+
+function default_policy_server_should_have_log_line {
+	policy_server_should_have_log_line default "$1"
+}
+
+function policy_server_should_have_log_line {
+	run kubectl --context $CLUSTER_CONTEXT logs -n $NAMESPACE -lapp="kubewarden-policy-server-$1" | grep "$2"
+}

--- a/tests/monitor-mode-tests.bats
+++ b/tests/monitor-mode-tests.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+source $BATS_TEST_DIRNAME/common.bash
+
+setup_file() {
+	kubectl --context $CLUSTER_CONTEXT delete --wait --ignore-not-found pods --all
+	kubectl --context $CLUSTER_CONTEXT delete --wait --ignore-not-found -n kubewarden clusteradmissionpolicies --all
+	kubectl --context $CLUSTER_CONTEXT wait --for=condition=Ready -n kubewarden pod --all
+}
+
+@test "[Monitor mode end-to-end tests] Install ClusterAdmissionPolicy in monitor mode" {
+	apply_cluster_admission_policy $RESOURCES_DIR/privileged-pod-policy-monitor.yaml
+}
+
+@test "[Monitor mode end-to-end tests] Launch a privileged pod should succeed" {
+	kubectl_apply_should_succeed $RESOURCES_DIR/violate-privileged-pod-policy.yaml
+	default_policy_server_should_have_log_line "policy evaluation (monitor mode)"
+	default_policy_server_should_have_log_line "allowed: false"
+	default_policy_server_should_have_log_line "cannot schedule privileged containers"
+	kubectl_delete $RESOURCES_DIR/violate-privileged-pod-policy.yaml
+}
+
+@test "[Monitor mode end-to-end tests] Transition policy mode from monitor to protect should succeed" {
+	apply_cluster_admission_policy $RESOURCES_DIR/privileged-pod-policy.yaml
+}
+
+@test "[Monitor mode end-to-end tests] Transition policy mode from protect to monitor should be disallowed" {
+	kubectl_apply_should_fail_with_message $RESOURCES_DIR/privileged-pod-policy-monitor.yaml "field cannot transition from protect to monitor. Recreate instead."
+}


### PR DESCRIPTION
Add basic monitor mode e2e tests.

This tests can be improved when we have more information exposed to the user, so it's possible to wait for a policy to have been promoted from `monitor` to `protect`, and run some tests after that has happened.

Until then, e2e tests for the monitor feature are the basic ones.