### PR TITLE
bump setup-kubewarden-cluster-action to v1.1.0

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           bats-version: 1.5.0
       - name: "Create Kubernetes cluster with Kubewarden installed"
-        uses: kubewarden/setup-kubewarden-cluster-action@v1
+        uses: kubewarden/setup-kubewarden-cluster-action@v1.1.0
         with:
           controller-image-repository: ${{ inputs.controller-image-repository }}
           controller-image-tag: ${{ inputs.controller-image-tag }}


### PR DESCRIPTION
## Description

Use latest version of setup-kubewarden-cluster-action so defaults helm chart is installed

Fix https://github.com/kubewarden/kubewarden-controller/issues/237
