### PR TITLE
 kubewarden-defaults values file and OpenTelemetry makefile targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,15 @@ delete-kubewarden:
 		--kube-context $(CLUSTER_CONTEXT) \
 		delete $(KUBEWARDEN_CRDS_CHART_RELEASE)
 
+.PHONY: delete-opentelemetry
+delete-opentelemetry: 
+	$(call kube, delete -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml)
+
+.PHONY: install-opentelemetry
+install-opentelemetry: install-cert-manager
+	$(call kube, apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml)
+	$(call kube, wait --for=condition=Available deployment --timeout=$(TIMEOUT) -n opentelemetry-operator-system --all)
+
 .PHONY: reconfiguration-test
 reconfiguration-test:
 	$(call bats, $(TESTS_DIR)/reconfiguration-tests.bats)

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ install-kubewarden: install-cert-manager install-kubewarden-chart-repo
 		$(KUBEWARDEN_CONTROLLER_CHART_RELEASE) $(KUBEWARDEN_CHARTS_LOCATION)/kubewarden-controller
 	helm upgrade --install --wait --namespace $(NAMESPACE) \
 		--kube-context $(CLUSTER_CONTEXT) \
+		--values $(RESOURCES_DIR)/default-kubewarden-defaults-values.yaml \
 		$(KUBEWARDEN_DEFAULTS_CHART_RELEASE) $(KUBEWARDEN_CHARTS_LOCATION)/kubewarden-defaults
 	$(call kube, wait --for=condition=Ready --namespace $(NAMESPACE) pods --all)
 

--- a/resources/default-kubewarden-controller-values.yaml
+++ b/resources/default-kubewarden-controller-values.yaml
@@ -1,3 +1,6 @@
+#image:
+#  repository: "ghcr.io/myuser/kubewarden-controller"
+#  tag: "latest"
 telemetry:
   enabled: false
 policyServer:

--- a/resources/default-kubewarden-defaults-values.yaml
+++ b/resources/default-kubewarden-defaults-values.yaml
@@ -1,0 +1,8 @@
+policyServer:
+#  image:
+#    repository: "ghcr.io/myuser/policy-server"
+#    tag: "latest"
+  telemetry:
+    enabled: False
+recommendedPolicies:
+  enabled: False


### PR DESCRIPTION
## Description

Adds a file to be used as the kubewarden-defaults values file. This file can be used to configure the deployment of the  kubewarden-defaults Helm chart.

Adds two new makefile targets to install and remove OpenTelemtry stack.
