### PR TITLE
Test versioned CRDs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+resources/resources_*/

--- a/scripts/generate_resources_dir.sh
+++ b/scripts/generate_resources_dir.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+RESOURCES_DIR=$1
+CRD_VERSION=$2
+
+rm -r $RESOURCES_DIR/resources_$CRD_VERSION
+mkdir $RESOURCES_DIR/resources_$CRD_VERSION
+
+find $RESOURCES_DIR -maxdepth 1 -type f  -exec cp \{\}  $RESOURCES_DIR/resources_$CRD_VERSION \;
+
+kubewarden_resources_files=$(grep -rl "apiVersion: policies.kubewarden.io" $RESOURCES_DIR/resouces_$CRD_VERSION)
+for file in $kubewarden_resources_files 
+do 
+	yq --in-place -Y ".apiVersion =\"policies.kubewarden.io/$CRD_VERSION\"" $file
+done


### PR DESCRIPTION
## Description

Updates the Makefile targets used to trigger the tests generating the resources files and updating the CRDs version used. Therefore, we can trigger tests for different CRDs versions. This is necessary due the close release of the CRDs v1.

Fix #25 

## Test

```shell
make CRD_VERSION=v1alpha2 create-k8s-cluster install-kubewarden basic-e2e-test
make CRD_VERSION=v1 create-k8s-cluster install-kubewarden basic-e2e-test
```
