### PR TITLE
Upgrade tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,14 @@ KUBEWARDEN_HELM_REPO_URL ?= https://charts.kubewarden.io
 # But the chart name must be equal of the names in the Helm chart repository.
 KUBEWARDEN_CHARTS_LOCATION ?= kubewarden
 
-KUBEWARDEN_CONTROLLER_CHART_VERSION ?= $(shell helm search repo $(KUBEWARDEN_HELM_REPO_NAME)/$(KUBEWARDEN_CONTROLLER_CHART_RELEASE) --versions -o json | jq ".[0].version" | sed "s/\"//g")
-KUBEWARDEN_CONTROLLER_CHART_OLD_VERSION ?= $(shell helm search repo $(KUBEWARDEN_HELM_REPO_NAME)/$(KUBEWARDEN_CONTROLLER_CHART_RELEASE) --versions -o json | jq ".[1].version" | sed "s/\"//g")
+KUBEWARDEN_CONTROLLER_CHART_VERSION ?= $(shell helm search repo $(KUBEWARDEN_HELM_REPO_NAME)/$(KUBEWARDEN_CONTROLLER_CHART_RELEASE) --versions -o json --devel | jq ".[0].version" | sed "s/\"//g")
+KUBEWARDEN_CONTROLLER_CHART_OLD_VERSION ?= $(shell helm search repo $(KUBEWARDEN_HELM_REPO_NAME)/$(KUBEWARDEN_CONTROLLER_CHART_RELEASE) --versions -o json --devel | jq ".[1].version" | sed "s/\"//g")
 KUBEWARDEN_CONTROLLER_CHART_RELEASE ?= kubewarden-controller
-KUBEWARDEN_CRDS_CHART_VERSION ?= $(shell helm search repo $(KUBEWARDEN_HELM_REPO_NAME)/$(KUBEWARDEN_CRDS_CHART_RELEASE) --versions -o json | jq ".[0].version" | sed "s/\"//g")
-KUBEWARDEN_CRDS_CHART_OLD_VERSION ?= $(shell helm search repo $(KUBEWARDEN_HELM_REPO_NAME)/$(KUBEWARDEN_CRDS_CHART_RELEASE) --versions -o json | jq ".[1].version" | sed "s/\"//g")
+KUBEWARDEN_CRDS_CHART_VERSION ?= $(shell helm search repo $(KUBEWARDEN_HELM_REPO_NAME)/$(KUBEWARDEN_CRDS_CHART_RELEASE) --versions -o json --devel | jq ".[0].version" | sed "s/\"//g")
+KUBEWARDEN_CRDS_CHART_OLD_VERSION ?= $(shell helm search repo $(KUBEWARDEN_HELM_REPO_NAME)/$(KUBEWARDEN_CRDS_CHART_RELEASE) --versions -o json --devel | jq ".[1].version" | sed "s/\"//g")
 KUBEWARDEN_CRDS_CHART_RELEASE ?= kubewarden-crds
-KUBEWARDEN_DEFAULTS_CHART_VERSION ?= $(shell helm search repo $(KUBEWARDEN_HELM_REPO_NAME)/$(KUBEWARDEN_DEFAULTS_CHART_RELEASE) --versions -o json | jq ".[0].version" | sed "s/\"//g")
-KUBEWARDEN_DEFAULTS_CHART_OLD_VERSION ?= $(shell helm search repo $(KUBEWARDEN_HELM_REPO_NAME)/$(KUBEWARDEN_DEFAULTS_CHART_RELEASE) --versions -o json | jq ".[1].version" | sed "s/\"//g")
+KUBEWARDEN_DEFAULTS_CHART_VERSION ?= $(shell helm search repo $(KUBEWARDEN_HELM_REPO_NAME)/$(KUBEWARDEN_DEFAULTS_CHART_RELEASE) --versions -o json --devel | jq ".[0].version" | sed "s/\"//g")
+KUBEWARDEN_DEFAULTS_CHART_OLD_VERSION ?= $(shell helm search repo $(KUBEWARDEN_HELM_REPO_NAME)/$(KUBEWARDEN_DEFAULTS_CHART_RELEASE) --versions -o json --devel | jq ".[1].version" | sed "s/\"//g")
 KUBEWARDEN_DEFAULTS_CHART_RELEASE ?= kubewarden-defaults
 CERT_MANAGER_VERSION ?= v1.5.3
 

--- a/scripts/generate_resources_dir.sh
+++ b/scripts/generate_resources_dir.sh
@@ -8,7 +8,7 @@ mkdir $RESOURCES_DIR/resources_$CRD_VERSION
 
 find $RESOURCES_DIR -maxdepth 1 -type f  -exec cp \{\}  $RESOURCES_DIR/resources_$CRD_VERSION \;
 
-kubewarden_resources_files=$(grep -rl "apiVersion: policies.kubewarden.io" $RESOURCES_DIR/resouces_$CRD_VERSION)
+kubewarden_resources_files=$(grep -rl "apiVersion: policies.kubewarden.io" $RESOURCES_DIR/resources_$CRD_VERSION)
 for file in $kubewarden_resources_files 
 do 
 	yq --in-place -Y ".apiVersion =\"policies.kubewarden.io/$CRD_VERSION\"" $file

--- a/scripts/generate_resources_dir.sh
+++ b/scripts/generate_resources_dir.sh
@@ -2,14 +2,15 @@
 
 RESOURCES_DIR=$1
 CRD_VERSION=$2
+CRD_SUFFIX=$3
 
-rm -r $RESOURCES_DIR/resources_$CRD_VERSION
-mkdir $RESOURCES_DIR/resources_$CRD_VERSION
+rm -r $RESOURCES_DIR/resources_$CRD_SUFFIX
+mkdir $RESOURCES_DIR/resources_$CRD_SUFFIX
 
-find $RESOURCES_DIR -maxdepth 1 -type f  -exec cp \{\}  $RESOURCES_DIR/resources_$CRD_VERSION \;
+find $RESOURCES_DIR -maxdepth 1 -type f  -exec cp \{\}  $RESOURCES_DIR/resources_$CRD_SUFFIX \;
 
-kubewarden_resources_files=$(grep -rl "apiVersion: policies.kubewarden.io" $RESOURCES_DIR/resources_$CRD_VERSION)
+kubewarden_resources_files=$(grep -rl "apiVersion: policies.kubewarden.io" $RESOURCES_DIR/resources_$CRD_SUFFIX)
 for file in $kubewarden_resources_files 
 do 
-	yq --in-place -Y ".apiVersion =\"policies.kubewarden.io/$CRD_VERSION\"" $file
+	yq --in-place -Y ".apiVersion =\"$CRD_VERSION\"" $file
 done

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -27,6 +27,11 @@ function kubectl_apply_should_succeed {
 	[ "$status" -eq 0 ]
 }
 
+function kubectl_namespace_apply_should_succeed {
+	run kubectl --context $CLUSTER_CONTEXT --namespace $2 apply --wait --timeout $TIMEOUT  -f $1
+	[ "$status" -eq 0 ]
+}
+
 function apply_cluster_admission_policy {
 	kubectl_apply_should_succeed $1
 	wait_for_all_cluster_admission_policies_to_be_active

--- a/tests/upgrade.bats
+++ b/tests/upgrade.bats
@@ -59,7 +59,14 @@ source $BATS_TEST_DIRNAME/common.bash
 
 @test "[CRD upgrade] Try to install a object with a old CRD version" {
 	apply_admission_policy $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
-	crd_version=$(kubectl --context $CLUSTER_CONTEXT get clusteradmissionpolicy -o json | jq -r ".items[].apiVersion" | uniq)
+	crd_version=$(kubectl --context $CLUSTER_CONTEXT get admissionPolicy -o json | jq -r ".items[].apiVersion" | uniq)
 	[ "$crd_version" = "policies.kubewarden.io/v1" ]
+}
+
+@test "[CRD upgrade] Privileged pod should be launched after delete old policies" {
+	kubectl --context $CLUSTER_CONTEXT delete --wait --ignore-not-found -n kubewarden clusteradmissionpolicies --all
+	kubectl --context $CLUSTER_CONTEXT create namespace testns
+
+	kubectl_namespace_apply_should_succeed $RESOURCES_DIR/violate-privileged-pod-policy.yaml testns
 }
 

--- a/tests/upgrade.bats
+++ b/tests/upgrade.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+source $BATS_TEST_DIRNAME/common.bash
+
+@test "[CRD upgrade] Install old Kubewarden version" {
+	helm install --wait --kube-context $CLUSTER_CONTEXT \
+		--namespace $NAMESPACE --create-namespace \
+		--version "$KUBEWARDEN_CRDS_CHART_OLD_VERSION" \
+		kubewarden-crds $KUBEWARDEN_CHARTS_LOCATION/kubewarden-crds
+
+	helm install --wait --namespace $NAMESPACE --kube-context $CLUSTER_CONTEXT \
+		--values $RESOURCES_DIR/default-kubewarden-controller-values.yaml \
+		--version "$KUBEWARDEN_CONTROLLER_CHART_OLD_VERSION" \
+		kubewarden-controller $KUBEWARDEN_CHARTS_LOCATION/kubewarden-controller
+
+	yq --in-place -Y ".recommendedPolicies.enabled=true" $RESOURCES_DIR/default-kubewarden-defaults-values.yaml
+	yq --in-place -Y ".recommendedPolicies.defaultPolicyMode=\"protect\"" $RESOURCES_DIR/default-kubewarden-defaults-values.yaml
+
+	helm install --wait --namespace $NAMESPACE --kube-context $CLUSTER_CONTEXT \
+		--values $RESOURCES_DIR/default-kubewarden-defaults-values.yaml \
+		--version "$KUBEWARDEN_DEFAULTS_CHART_OLD_VERSION" \
+		kubewarden-defaults $KUBEWARDEN_CHARTS_LOCATION/kubewarden-defaults
+
+	crd_version=$(kubectl --context $CLUSTER_CONTEXT get clusteradmissionpolicy -o json | jq -r ".items[].apiVersion" | uniq)
+	[ "$crd_version" = "policies.kubewarden.io/v1alpha2" ]
+	wait_for_all_cluster_admission_policy_condition PolicyUniquelyReachable
+}
+
+@test "[CRD upgrade] Launch a privileged pod should fail" {
+	kubectl_apply_should_fail $RESOURCES_DIR/violate-privileged-pod-policy.yaml
+}
+
+@test "[CRD upgrade] Upgrade CRDs" {
+	helm upgrade --wait --kube-context $CLUSTER_CONTEXT \
+		--namespace $NAMESPACE --create-namespace \
+		--version $KUBEWARDEN_CRDS_CHART_VERSION \
+		kubewarden-crds $KUBEWARDEN_CHARTS_LOCATION/kubewarden-crds
+
+	helm upgrade --wait --namespace $NAMESPACE --kube-context $CLUSTER_CONTEXT \
+		--values $RESOURCES_DIR/default-kubewarden-controller-values.yaml \
+		--version $KUBEWARDEN_CONTROLLER_CHART_VERSION \
+		kubewarden-controller $KUBEWARDEN_CHARTS_LOCATION/kubewarden-controller
+
+	yq --in-place -Y ".recommendedPolicies.enabled=true" $RESOURCES_DIR/default-kubewarden-defaults-values.yaml
+	yq --in-place -Y ".recommendedPolicies.defaultPolicyMode=\"protect\"" $RESOURCES_DIR/default-kubewarden-defaults-values.yaml
+	helm upgrade --wait --namespace $NAMESPACE --kube-context $CLUSTER_CONTEXT \
+		--values $RESOURCES_DIR/default-kubewarden-defaults-values.yaml \
+		--version $KUBEWARDEN_DEFAULTS_CHART_VERSION \
+		kubewarden-defaults $KUBEWARDEN_CHARTS_LOCATION/kubewarden-defaults
+
+	crd_version=$(kubectl --context $CLUSTER_CONTEXT get clusteradmissionpolicy -o json | jq -r ".items[].apiVersion" | uniq)
+	[ "$crd_version" = "policies.kubewarden.io/v1" ]
+	wait_for_all_cluster_admission_policy_condition PolicyUniquelyReachable
+}
+
+@test "[CRD upgrade] Launch a privileged pod should fail after CRD upgrade" {
+	kubectl_apply_should_fail $RESOURCES_DIR/violate-privileged-pod-policy.yaml
+}
+
+@test "[CRD upgrade] Try to install a object with a old CRD version" {
+	apply_admission_policy $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
+	crd_version=$(kubectl --context $CLUSTER_CONTEXT get clusteradmissionpolicy -o json | jq -r ".items[].apiVersion" | uniq)
+	[ "$crd_version" = "policies.kubewarden.io/v1" ]
+}
+


### PR DESCRIPTION
Adds test script to validate the Helm chart upgrades.

## Test

```shell
make KUBEWARDEN_HELM_REPO_URL=http://jvanz.com/helm-charts/ KUBEWARDEN_DEFAULTS_CHART_OLD_VERSION=0.1.5 upgrade-test
```
