### PR TITLE
Run test v0.2.3.

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           repository: "${{ github.repository_owner }}/kubewarden-end-to-end-tests"
           path: "e2e-tests"
-          ref: "v0.2.0"
+          ref: "v0.2.3"
           fetch-depth: 0
       - name: "Setup bats testing framework"
         uses: mig4/setup-bats@v1.2.0


### PR DESCRIPTION
Updates the workflow used to run the E2E tests to run the test version v0.2.3.

The tag `v0.2.3` will be created as soon as this PR is merged.