### PR TITLE
Cleanup e2e tests

### DIFF
--- a/resources/mutate-pod-psp-user-group-policy.yaml
+++ b/resources/mutate-pod-psp-user-group-policy.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Pod
-metadata:
-  name: pause-user-group
-spec:
-  containers:
-    - name: pause
-      image: k8s.gcr.io/pause
-

--- a/tests/basic-end-to-end-tests.bats
+++ b/tests/basic-end-to-end-tests.bats
@@ -20,10 +20,7 @@ teardown_file() {
 	kubectl wait --for=condition=Ready pod nginx-unprivileged
 
 	# Launch privileged pod (should fail)
-	run kubectl run nginx-privileged --image=nginx:alpine --privileged
-	assert_failure
-	assert_output --regexp '^Error.*: admission webhook.*denied the request.*cannot schedule privileged containers$'
-	run ! kubectl get pods nginx-privileged
+	kubefail_privileged run pod-privileged --image=k8s.gcr.io/pause --privileged
 }
 
 # Update pod-privileged policy to block only UPDATE of privileged pods
@@ -34,9 +31,7 @@ teardown_file() {
 	kubectl run nginx-privileged --image=nginx:alpine --privileged
 
 	# I can not update privileged pods
-	run kubectl label pod nginx-privileged x=y
-	assert_failure
-	assert_output --regexp '^Error.*: admission webhook.*denied the request.*cannot schedule privileged containers$'
+	kubefail_privileged label pod nginx-privileged x=y
 }
 
 @test "[Basic end-to-end tests] Delete ClusterAdmissionPolicy" {

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -67,19 +67,15 @@ function kubectl_apply_should_fail_with_message {
 	assert_output --partial "$2"
 }
 
-function kubectl_apply {
-	kubectl apply -f $1
-}
-
 function apply_cluster_admission_policy {
-	kubectl_apply $1
+	kubectl apply -f $1
 	wait_for_cluster_admission_policy PolicyActive
 	wait_for_default_policy_server_rollout
 	wait_for_cluster_admission_policy PolicyUniquelyReachable
 }
 
 function apply_admission_policy {
-	kubectl_apply $1
+	kubectl apply -f $1
 	wait_for_admission_policy PolicyActive
 	wait_for_default_policy_server_rollout
 	wait_for_admission_policy PolicyUniquelyReachable

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -85,12 +85,8 @@ function kubectl_delete {
 	kubectl delete --ignore-not-found -f $1
 }
 
-function kubectl_delete_by_type_and_name {
-	kubectl -n $NAMESPACE delete --ignore-not-found $1 $2
-}
-
 function kubectl_delete_configmap_by_name {
-	kubectl_delete_by_type_and_name configmap $1
+	kubectl -n $NAMESPACE delete --ignore-not-found configmap $1
 }
 
 function wait_for_admission_policy {

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -81,10 +81,6 @@ function apply_admission_policy {
 	wait_for_admission_policy PolicyUniquelyReachable
 }
 
-function kubectl_delete {
-	kubectl delete --ignore-not-found -f $1
-}
-
 function kubectl_delete_configmap_by_name {
 	kubectl -n $NAMESPACE delete --ignore-not-found configmap $1
 }

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -56,6 +56,13 @@ function wait_cluster() {
     wait_pods
 }
 
+# Run kubectl action which should fail on pod privileged policy
+function kubefail_privileged {
+	run kubectl "$@"
+	assert_failure 1
+	assert_output --regexp '^Error.*: admission webhook.*denied the request.*cannot schedule privileged containers$'
+}
+
 function kubectl_apply_should_fail {
 	run kubectl apply -f $1
 	assert_failure

--- a/tests/monitor-mode-tests.bats
+++ b/tests/monitor-mode-tests.bats
@@ -26,10 +26,7 @@ teardown_file() {
 	apply_cluster_admission_policy $RESOURCES_DIR/privileged-pod-policy.yaml
 
 	# Launch privileged pod (should fail)
-	run kubectl run nginx-privileged --image=nginx:alpine --privileged
-	assert_failure
-	assert_output --regexp '^Error.*: admission webhook.*denied the request.*cannot schedule privileged containers$'
-	run ! kubectl get pods nginx-privileged
+	kubefail_privileged run pod-privileged --image=k8s.gcr.io/pause --privileged
 }
 
 @test "[Monitor mode end-to-end tests] Transition from protect to monitor should be disallowed" {

--- a/tests/monitor-mode-tests.bats
+++ b/tests/monitor-mode-tests.bats
@@ -15,7 +15,7 @@ teardown_file() {
 }
 
 @test "[Monitor mode end-to-end tests] Launch a privileged pod should succeed" {
-	kubectl_apply $RESOURCES_DIR/violate-privileged-pod-policy.yaml
+	kubectl apply -f $RESOURCES_DIR/violate-privileged-pod-policy.yaml
 	default_policy_server_should_have_log_line "policy evaluation (monitor mode)"
 	default_policy_server_should_have_log_line "allowed: false"
 	default_policy_server_should_have_log_line "cannot schedule privileged containers"

--- a/tests/namespaced-admission-policy-tests.bats
+++ b/tests/namespaced-admission-policy-tests.bats
@@ -7,25 +7,21 @@ setup() {
 
 teardown_file() {
 	kubectl delete pods --all
-	kubectl delete -f $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml --ignore-not-found
+	kubectl delete -f $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
 }
 
-@test "[Namespaced AdmissionPolicy] Install AdmissionPolicy" {
+@test "[Namespaced AdmissionPolicy] Test AdmissionPolicy in default NS" {
 	apply_admission_policy $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
-}
 
-@test "[Namespaced AdmissionPolicy] Privileged pod in the default namespace (should fail)" {
-	# Launch privileged pod (should fail)
+	# Privileged pod in the default namespace (should fail)
 	kubefail_privileged run nginx-privileged --image=nginx:alpine --privileged
-}
 
-@test "[Namespaced AdmissionPolicy] Privileged pod in the kubewarden namespace (should work)" {
+	# Privileged pod in the kubewarden namespace (should work)
 	kubectl run nginx-privileged --image=nginx:alpine --privileged -n kubewarden
 	kubectl wait --for=condition=Ready pod nginx-privileged -n kubewarden
 	kubectl delete pod nginx-privileged -n kubewarden
-}
 
-@test  "[Namespaced AdmissionPolicy] Unprivileged pod in default namespace (should work)" {
+	# Unprivileged pod in default namespace (should work)
 	kubectl run nginx-unprivileged --image=nginx:alpine
 	kubectl wait --for=condition=Ready pod nginx-unprivileged
 	kubectl delete pod nginx-unprivileged
@@ -33,22 +29,18 @@ teardown_file() {
 
 @test  "[Namespaced AdmissionPolicy] Update policy to check only UPDATE operations" {
 	yq '.spec.rules[0].operations = ["UPDATE"]' resources/namespaced-privileged-pod-policy.yaml | kubectl apply -f -
-}
 
-@test "[Namespaced AdmissionPolicy] Privileged pod in the default namespace (can't update)" {
 	# I can create privileged pods now
 	kubectl run nginx-privileged --image=nginx:alpine --privileged
 
-	# I can not update privileged pods
+	# I still can not update privileged pods
 	kubefail_privileged label pod nginx-privileged x=y
 	kubectl delete pod nginx-privileged
 }
 
-@test "[Namespaced AdmissionPolicy] Delete AdmissionPolicy" {
+@test "[Namespaced AdmissionPolicy] Delete AdmissionPolicy to check restrictions are removed" {
 	kubectl delete -f $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
-}
 
-@test "[Namespaced AdmissionPolicy] Privileged pod in the default namespace (no restrictions)" {
 	# I can create privileged pods
 	kubectl run nginx-privileged --image=nginx:alpine --privileged
 

--- a/tests/namespaced-admission-policy-tests.bats
+++ b/tests/namespaced-admission-policy-tests.bats
@@ -24,7 +24,7 @@ teardown_file() {
 }
 
 @test  "[AdmissionPolicy tests] Launch a pod which does not violate privileged pod policy" {
-	kubectl_apply $RESOURCES_DIR/not-violate-privileged-pod-policy.yaml
+	kubectl apply -f $RESOURCES_DIR/not-violate-privileged-pod-policy.yaml
 }
 
 @test  "[AdmissionPolicy tests] Update privileged pod policy to check only UPDATE operations" {
@@ -32,7 +32,7 @@ teardown_file() {
 }
 
 @test "[AdmissionPolicy tests] Launch a pod which violate privileged pod policy after policy change should work" {
-	kubectl_apply $RESOURCES_DIR/violate-privileged-pod-policy.yaml
+	kubectl apply -f $RESOURCES_DIR/violate-privileged-pod-policy.yaml
 }
 
 @test "[AdmissionPolicy tests] Delete AdmissionPolicy" {
@@ -40,5 +40,5 @@ teardown_file() {
 }
 
 @test "[AdmissionPolicy tests] Launch a pod which violate privileged pod policy after policy deletion should work" {
-	kubectl_apply $RESOURCES_DIR/violate-privileged-pod-policy.yaml
+	kubectl apply -f $RESOURCES_DIR/violate-privileged-pod-policy.yaml
 }

--- a/tests/namespaced-admission-policy-tests.bats
+++ b/tests/namespaced-admission-policy-tests.bats
@@ -16,10 +16,7 @@ teardown_file() {
 
 @test "[Namespaced AdmissionPolicy] Privileged pod in the default namespace (should fail)" {
 	# Launch privileged pod (should fail)
-	run kubectl run nginx-privileged --image=nginx:alpine --privileged
-	assert_failure
-	assert_output --regexp '^Error.*: admission webhook.*denied the request.*cannot schedule privileged containers$'
-	run ! kubectl get pods nginx-privileged
+	kubefail_privileged run nginx-privileged --image=nginx:alpine --privileged
 }
 
 @test "[Namespaced AdmissionPolicy] Privileged pod in the kubewarden namespace (should work)" {
@@ -43,10 +40,7 @@ teardown_file() {
 	kubectl run nginx-privileged --image=nginx:alpine --privileged
 
 	# I can not update privileged pods
-	run kubectl label pod nginx-privileged x=y
-	assert_failure
-	assert_output --regexp '^Error.*: admission webhook.*denied the request.*cannot schedule privileged containers$'
-
+	kubefail_privileged label pod nginx-privileged x=y
 	kubectl delete pod nginx-privileged
 }
 

--- a/tests/reconfiguration-tests.bats
+++ b/tests/reconfiguration-tests.bats
@@ -31,8 +31,5 @@ teardown_file() {
 	kubectl wait --for=condition=Ready pod pause-unprivileged
 
 	# Launch privileged pod (should fail)
-	run kubectl run pause-privileged --image k8s.gcr.io/pause --privileged
-	assert_failure
-	assert_output --regexp '^Error.*: admission webhook.*denied the request.*cannot schedule privileged containers$'
-	run ! kubectl get pods pause-privileged
+	kubefail_privileged run pause-privileged --image k8s.gcr.io/pause --privileged
 }

--- a/tests/secure-supply-chain-tests.bats
+++ b/tests/secure-supply-chain-tests.bats
@@ -27,7 +27,7 @@ setup() {
 
 @test "[Secure Supply Chain tests] Untrusted policy should block policy server to run" {
 	create_configmap_from_file_with_root_key $SECURE_SUPPLY_CHAIN_VERIFICATION_CONFIG_MAP_NAME verification-config $RESOURCES_DIR/restricted-secure-supply-chain-verification-config.yaml
-	kubectl_delete $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
+	kubectl delete -f $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
 	wait_for_default_policy_server_rollout
 	helm upgrade --set policyServer.verificationConfig=$SECURE_SUPPLY_CHAIN_VERIFICATION_CONFIG_MAP_NAME --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults
 	wait_for_default_policy_server_rollout

--- a/tests/secure-supply-chain-tests.bats
+++ b/tests/secure-supply-chain-tests.bats
@@ -31,7 +31,7 @@ setup() {
 	wait_for_default_policy_server_rollout
 	helm upgrade --set policyServer.verificationConfig=$SECURE_SUPPLY_CHAIN_VERIFICATION_CONFIG_MAP_NAME --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults
 	wait_for_default_policy_server_rollout
-	kubectl_apply $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
+	kubectl apply -f $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
 	# Policy Server startup should fail
 	default_policy_server_rollout_should_fail
 }


### PR DESCRIPTION
## Description

- remove functions used only once or without added value
- replace `kubectl apply -f yaml` with `kubectl run --image` to make workflow more obvious
- remove random or default `--wait` & `--timeout` parameters
- cleanup test files

## Test

https://github.com/kravciak/kubewarden-controller/runs/7899383435?check_suite_focus=true