### PR TITLE
Fix secure supply chain test

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,7 +61,7 @@ jobs:
           policy-server-container-image-artifact: ${{ inputs.policy-server-container-image-artifact }}
       - name: "Run all end-to-end tests"
         run: |
-          make --directory e2e-tests basic-e2e-test reconfiguration-test mutating-requests-test monitor-mode-test namespaced-admission-policy-test
+          make --directory e2e-tests basic-e2e-test reconfiguration-test mutating-requests-test monitor-mode-test namespaced-admission-policy-test secure-supply-chain-test
         shell: bash
         env:
           CLUSTER_CONTEXT: k3d-kubewarden-test-cluster #TODO get context from setup-kubewarden-cluster-action

--- a/resources/namespaced-privileged-pod-policy.yaml
+++ b/resources/namespaced-privileged-pod-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: privileged-pods
 spec:
   policyServer: default
-  module: registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.10
+  module: registry://ghcr.io/kubewarden/tests/pod-privileged:v0.2.1
   rules:
   - apiGroups: [""]
     apiVersions: ["v1"]

--- a/resources/policy-pod-privileged.yaml
+++ b/resources/policy-pod-privileged.yaml
@@ -1,7 +1,7 @@
 apiVersion: policies.kubewarden.io/v1alpha2
 kind: AdmissionPolicy
 metadata:
-  name: privileged-pods
+  name: pod-privileged
 spec:
   policyServer: default
   module: registry://ghcr.io/kubewarden/tests/pod-privileged:v0.2.1

--- a/resources/privileged-pod-policy-monitor.yaml
+++ b/resources/privileged-pod-policy-monitor.yaml
@@ -4,7 +4,7 @@ metadata:
   name: privileged-pods
 spec:
   policyServer: default
-  module: registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.10
+  module: registry://ghcr.io/kubewarden/tests/pod-privileged:v0.2.1
   mode: monitor
   rules:
   - apiGroups: [""]

--- a/resources/privileged-pod-policy.yaml
+++ b/resources/privileged-pod-policy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: privileged-pods
 spec:
   policyServer: default
-  module: registry://ghcr.io/kubewarden/tests/pod-privileged:v0.1.10
+  module: registry://ghcr.io/kubewarden/tests/pod-privileged:v0.2.1
   namespaceSelector:
     matchExpressions:
       - key: "kubernetes.io/metadata.name"

--- a/resources/secure-supply-chain-cm-restricted.yaml
+++ b/resources/secure-supply-chain-cm-restricted.yaml
@@ -11,13 +11,12 @@
 ---
 apiVersion: v1
 allOf:
-  - kind: githubAction
-    owner: kubewarden
-    repo: ~
-    annotations: ~
-  - kind: genericIssuer
-    issuer: https://github.com/login/oauth
-    subject:
-      equal: alice@example.com
+  - kind: pubKey
+    key: |
+      -----BEGIN PUBLIC KEY-----
+      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQiTy5S+2JFvVlhUwWPLziM7iTM2j
+      byLgh2IjpNQN0Uio/9pZOTP/CsJmXoUNshfpTUHd3OxgHgz/6adtf2nBwQ==
+      -----END PUBLIC KEY-----
+    annotations:
+      env: thefail
 anyOf: ~
-

--- a/resources/secure-supply-chain-cm.yaml
+++ b/resources/secure-supply-chain-cm.yaml
@@ -11,9 +11,12 @@
 ---
 apiVersion: v1
 allOf:
-  - kind: githubAction
-    owner: kubewarden
-    repo: ~
-    annotations: ~
+  - kind: pubKey
+    key: |
+      -----BEGIN PUBLIC KEY-----
+      MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQiTy5S+2JFvVlhUwWPLziM7iTM2j
+      byLgh2IjpNQN0Uio/9pZOTP/CsJmXoUNshfpTUHd3OxgHgz/6adtf2nBwQ==
+      -----END PUBLIC KEY-----
+    annotations:
+      env: prod
 anyOf: ~
-

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -60,7 +60,7 @@ function wait_cluster() {
 function kubefail_privileged {
 	run kubectl "$@"
 	assert_failure 1
-	assert_output --regexp '^Error.*: admission webhook.*denied the request.*cannot schedule privileged containers$'
+	assert_output --regexp '^Error.*: admission webhook.*denied the request.*container is not allowed$'
 }
 
 function kubectl_apply_should_fail {

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -88,10 +88,6 @@ function apply_admission_policy {
 	wait_for_admission_policy PolicyUniquelyReachable
 }
 
-function kubectl_delete_configmap_by_name {
-	kubectl -n $NAMESPACE delete --ignore-not-found configmap $1
-}
-
 function wait_for_admission_policy {
 	wait_for --for=condition="$1" admissionpolicies --all -A
 }
@@ -105,16 +101,6 @@ function wait_for_default_policy_server_rollout {
 	wait_rollout -n $NAMESPACE --revision $revision "deployment/policy-server-default"
 }
 
-function default_policy_server_rollout_should_fail {
-	revision=$(kubectl -n $NAMESPACE get "deployment/policy-server-default" -o json | jq -r '.metadata.annotations."deployment.kubernetes.io/revision"')
-	run kubectl -n $NAMESPACE rollout status --revision $revision "deployment/policy-server-default"
-	assert_failure
-}
-
 function default_policy_server_should_have_log_line {
 	kubectl logs -n $NAMESPACE -lapp="kubewarden-policy-server-default" | grep "$1"
-}
-
-function create_configmap_from_file_with_root_key {
-	kubectl -n $NAMESPACE create configmap $1 --from-file=$2=$3
 }

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -100,7 +100,3 @@ function wait_for_default_policy_server_rollout {
 	revision=$(kubectl -n $NAMESPACE get "deployment/policy-server-default" -o json | jq -r '.metadata.annotations."deployment.kubernetes.io/revision"')
 	wait_rollout -n $NAMESPACE --revision $revision "deployment/policy-server-default"
 }
-
-function default_policy_server_should_have_log_line {
-	kubectl logs -n $NAMESPACE -lapp="kubewarden-policy-server-default" | grep "$1"
-}

--- a/tests/monitor-mode-tests.bats
+++ b/tests/monitor-mode-tests.bats
@@ -16,9 +16,10 @@ teardown_file() {
 
 @test "[Monitor mode end-to-end tests] Monitor mode should only log event" {
 	kubectl run nginx-privileged --image=nginx:alpine --privileged
-	default_policy_server_should_have_log_line "policy evaluation (monitor mode)"
-	default_policy_server_should_have_log_line "allowed: false"
-	default_policy_server_should_have_log_line "Privileged container is not allowed"
+	run kubectl logs -n $NAMESPACE -lapp="kubewarden-policy-server-default"
+	assert_output -p "policy evaluation (monitor mode)"
+	assert_output -p "allowed: false"
+	assert_output -p "Privileged container is not allowed"
 	kubectl delete pod nginx-privileged
 }
 

--- a/tests/monitor-mode-tests.bats
+++ b/tests/monitor-mode-tests.bats
@@ -18,7 +18,7 @@ teardown_file() {
 	kubectl run nginx-privileged --image=nginx:alpine --privileged
 	default_policy_server_should_have_log_line "policy evaluation (monitor mode)"
 	default_policy_server_should_have_log_line "allowed: false"
-	default_policy_server_should_have_log_line "cannot schedule privileged containers"
+	default_policy_server_should_have_log_line "Privileged container is not allowed"
 	kubectl delete pod nginx-privileged
 }
 

--- a/tests/namespaced-admission-policy-tests.bats
+++ b/tests/namespaced-admission-policy-tests.bats
@@ -7,11 +7,11 @@ setup() {
 
 teardown_file() {
 	kubectl delete pods --all
-	kubectl delete -f $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml --ignore-not-found
+	kubectl delete -f $RESOURCES_DIR/policy-pod-privileged.yaml --ignore-not-found
 }
 
 @test "[Namespaced AdmissionPolicy] Test AdmissionPolicy in default NS" {
-	apply_admission_policy $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
+	apply_admission_policy $RESOURCES_DIR/policy-pod-privileged.yaml
 
 	# Privileged pod in the default namespace (should fail)
 	kubefail_privileged run nginx-privileged --image=nginx:alpine --privileged
@@ -28,7 +28,7 @@ teardown_file() {
 }
 
 @test  "[Namespaced AdmissionPolicy] Update policy to check only UPDATE operations" {
-	yq '.spec.rules[0].operations = ["UPDATE"]' resources/namespaced-privileged-pod-policy.yaml | kubectl apply -f -
+	yq '.spec.rules[0].operations = ["UPDATE"]' $RESOURCES_DIR/policy-pod-privileged.yaml | kubectl apply -f -
 
 	# I can create privileged pods now
 	kubectl run nginx-privileged --image=nginx:alpine --privileged
@@ -39,7 +39,7 @@ teardown_file() {
 }
 
 @test "[Namespaced AdmissionPolicy] Delete AdmissionPolicy to check restrictions are removed" {
-	kubectl delete -f $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
+	kubectl delete -f $RESOURCES_DIR/policy-pod-privileged.yaml
 
 	# I can create privileged pods
 	kubectl run nginx-privileged --image=nginx:alpine --privileged

--- a/tests/secure-supply-chain-tests.bats
+++ b/tests/secure-supply-chain-tests.bats
@@ -18,7 +18,7 @@ setup() {
 
 teardown() {
 	kubectl -n $NAMESPACE delete configmap $CONFIGMAP_NAME
-	kubectl delete -f $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
+	kubectl delete -f $RESOURCES_DIR/policy-pod-privileged.yaml
 }
 
 # Configure kubewarden to check policy signatures
@@ -52,7 +52,7 @@ function get_policy_server_status {
 	wait_rollout -n $NAMESPACE "deployment/policy-server-default"
 
 	# Policy Server should start fine
-	apply_admission_policy $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
+	apply_admission_policy $RESOURCES_DIR/policy-pod-privileged.yaml
 
 	# Check logs of last policyserver pod
 	run -0 get_policy_server_status
@@ -66,7 +66,7 @@ function get_policy_server_status {
 	create_configmap $RESOURCES_DIR/secure-supply-chain-cm-restricted.yaml
 
 	# Policy Server should start fine
-	kubectl apply -f $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
+	kubectl apply -f $RESOURCES_DIR/policy-pod-privileged.yaml
 
 	# Policy Server startup should fail
 	run kubectl -n $NAMESPACE rollout status --timeout=1m "deployment/policy-server-default"

--- a/tests/secure-supply-chain-tests.bats
+++ b/tests/secure-supply-chain-tests.bats
@@ -13,7 +13,7 @@ CONFIGMAP_NAME="ssc-verification-config"
 
 setup() {
 	load common.bash
-	wait_pods # -n kubewarden
+	wait_pods
 }
 
 teardown() {

--- a/tests/secure-supply-chain-tests.bats
+++ b/tests/secure-supply-chain-tests.bats
@@ -1,38 +1,81 @@
 #!/usr/bin/env bats
+#
+# This test requires signed package. To sign follow this steps & modify configmaps accordingly
+# $ kwctl pull registry://ghcr.io/kubewarden/policies/pod-privileged:v0.2.1
+# $ kwctl push
+#    ~/.cache/kubewarden/store/registry/ghcr.io/kubewarden/policies/pod-privileged:v0.2.1 \
+#    ghcr.io/kubewarden/tests/pod-privileged:v0.2.1
+# $ COSIGN_PASSWORD=kubewarden cosign generate-key-pair
+# $ COSIGN_PASSWORD=kubewarden cosign sign --key cosign.key -a env=prod ghcr.io/kubewarden/tests/pod-privileged:v0.2.1
 
-source $BATS_TEST_DIRNAME/common.bash
 
-SECURE_SUPPLY_CHAIN_VERIFICATION_CONFIG_MAP_NAME="ssc-verification-config"
-
-teardown_file() {
-	helm upgrade --set policyServer.verificationConfig="" --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults
-	wait_for_default_policy_server_rollout
-	kubectl_delete_configmap_by_name $SECURE_SUPPLY_CHAIN_VERIFICATION_CONFIG_MAP_NAME
-}
+CONFIGMAP_NAME="ssc-verification-config"
 
 setup() {
-	kubectl delete --wait --ignore-not-found pods --all
-	kubectl delete --wait --ignore-not-found -n kubewarden clusteradmissionpolicies --all
-	kubectl delete --wait --ignore-not-found -n kubewarden admissionpolicies --all
-	kubectl wait --for=condition=Ready -n kubewarden pod --all
-	kubectl_delete_configmap_by_name $SECURE_SUPPLY_CHAIN_VERIFICATION_CONFIG_MAP_NAME
+	load common.bash
+	wait_pods # -n kubewarden
+}
+
+teardown() {
+	kubectl -n $NAMESPACE delete configmap $CONFIGMAP_NAME
+	kubectl delete -f $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
+}
+
+# Configure kubewarden to check policy signatures
+# https://docs.kubewarden.io/distributing-policies/secure-supply-chain#configuring-the-policy-server-to-check-policy-signatures
+setup_file() {
+	helm upgrade -n kubewarden --set policyServer.verificationConfig=$CONFIGMAP_NAME --wait kubewarden-defaults kubewarden/kubewarden-defaults
+	kubectl get policyserver default -o json | jq -e --arg cmname $CONFIGMAP_NAME '.spec.verificationConfig == $cmname'
+	# don't wait for rollout here, it needs configmap to run
+}
+
+teardown_file() {
+	helm upgrade -n kubewarden --set policyServer.verificationConfig="" --wait kubewarden-defaults kubewarden/kubewarden-defaults
+}
+
+function create_configmap {
+	kubectl -n $NAMESPACE create configmap $CONFIGMAP_NAME --from-file=verification-config=$1
+}
+
+function get_policy_server_status {
+	# get latest policy-server pod
+	local podname=$(kubectl get pods -n kubewarden --selector=app=kubewarden-policy-server-default --sort-by=.metadata.creationTimestamp -o jsonpath="{.items[-1].metadata.name}")
+	# fill output with logs, 10s timeout because pod restart cleans up
+	kubectl logs -n kubewarden $podname --request-timeout=10s -f
+
+	# fill exit code with pod status
+	kubectl get pod -n kubewarden $podname -o json | jq -e '.status.containerStatuses[0].ready == true'
 }
 
 @test "[Secure Supply Chain tests] Trusted policy should not block policy server" {
-	create_configmap_from_file_with_root_key $SECURE_SUPPLY_CHAIN_VERIFICATION_CONFIG_MAP_NAME verification-config $RESOURCES_DIR/secure-supply-chain-verification-config.yaml
-	helm upgrade --set policyServer.verificationConfig=$SECURE_SUPPLY_CHAIN_VERIFICATION_CONFIG_MAP_NAME --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults
-	# this function will wait the policy server to rollout. Which shows that signatures are valid
+	create_configmap $RESOURCES_DIR/secure-supply-chain-cm.yaml
+	wait_rollout -n $NAMESPACE "deployment/policy-server-default"
+
+	# Policy Server should start fine
 	apply_admission_policy $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
+
+	# Check logs of last policyserver pod
+	run -0 get_policy_server_status
+	assert_output -p 'verifying policy authenticity and integrity using sigstore'
+	assert_output -p 'Local file checksum verification passed'
+
+	# Cleanup moved to teardown
 }
 
 @test "[Secure Supply Chain tests] Untrusted policy should block policy server to run" {
-	create_configmap_from_file_with_root_key $SECURE_SUPPLY_CHAIN_VERIFICATION_CONFIG_MAP_NAME verification-config $RESOURCES_DIR/restricted-secure-supply-chain-verification-config.yaml
-	kubectl delete -f $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
-	wait_for_default_policy_server_rollout
-	helm upgrade --set policyServer.verificationConfig=$SECURE_SUPPLY_CHAIN_VERIFICATION_CONFIG_MAP_NAME --wait -n kubewarden kubewarden-defaults kubewarden/kubewarden-defaults
-	wait_for_default_policy_server_rollout
-	kubectl apply -f $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
-	# Policy Server startup should fail
-	default_policy_server_rollout_should_fail
-}
+	create_configmap $RESOURCES_DIR/secure-supply-chain-cm-restricted.yaml
 
+	# Policy Server should start fine
+	kubectl apply -f $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
+
+	# Policy Server startup should fail
+	run kubectl -n $NAMESPACE rollout status --timeout=1m "deployment/policy-server-default"
+	assert_failure 1
+
+	# Check logs of last policyserver pod
+	run -1 get_policy_server_status
+	assert_output -p 'Annotation not satisfied'
+	assert_output -p 'policy cannot be verified'
+
+	# Cleanup moved to teardown
+}

--- a/tests/upgrade.bats
+++ b/tests/upgrade.bats
@@ -61,7 +61,7 @@ setup() {
 }
 
 @test "[CRD upgrade] Try to install a object with a old CRD version" {
-	apply_admission_policy $RESOURCES_DIR/namespaced-privileged-pod-policy.yaml
+	apply_admission_policy $RESOURCES_DIR/policy-pod-privileged.yaml
 	crd_version=$(kubectl --context $CLUSTER_CONTEXT get admissionPolicy -o json | jq -r ".items[].apiVersion" | uniq)
 	[ "$crd_version" = "policies.kubewarden.io/v1" ]
 }


### PR DESCRIPTION
## Description

Test was not passing because test packages were not signed.
 - modified configmap for testing pass / fail of signature verification
 - removed extra functions from common.bash
 - added checks for log events & policy server pod status
 - added instructions for creating signed package
 - added timeouts to speed up waiting for failed rollout
 - add test to e2e workflow

## Test

https://github.com/kravciak/kubewarden-controller/runs/8005139693?check_suite_focus=true