### PR TITLE
Reorganize makefile

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,7 +61,7 @@ jobs:
           policy-server-container-image-artifact: ${{ inputs.policy-server-container-image-artifact }}
       - name: "Run all end-to-end tests"
         run: |
-          make --directory e2e-tests basic-e2e-test reconfiguration-test mutating-requests-test monitor-mode-test namespaced-admission-policy-test secure-supply-chain-test
+          make --directory e2e-tests tests
         shell: bash
         env:
           CLUSTER_CONTEXT: k3d-kubewarden-test-cluster #TODO get context from setup-kubewarden-cluster-action

--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,7 @@ $(TESTS)::
 .PHONY: tests
 tests: $(filter-out upgrade.bats, $(TESTS))
 
-.PHONY: prepare cluster install reinstall clean
-prepare: 
-	curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+.PHONY: cluster install reinstall clean
 
 cluster:
 	k3d cluster create $(CLUSTER_NAME) -s 1 -a 1 --wait --timeout $(TIMEOUT) -v /dev/mapper:/dev/mapper

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL := basic-end-to-end-tests.bats
+
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 mkfile_dir := $(dir $(mkfile_path))
 TESTS_DIR ?= $(mkfile_dir)tests
@@ -40,7 +42,10 @@ RESOURCES_DIR ?= $(ROOT_RESOURCES_DIR)/resources_$(CRD_VERSION_SUFFIX)
 CLUSTER_NAME ?= kubewarden-testing #$(shell echo kubewarden-tests-$(KUBEWARDEN_CONTROLLER_CHART_VERSION) | sed 's/\./-/g')
 CLUSTER_CONTEXT ?= k3d-$(CLUSTER_NAME)
 
+# ==================================================================================================
+# Aliases
 kube = kubectl --context $(CLUSTER_CONTEXT) $(1)
+helm = helm --kube-context $(CLUSTER_CONTEXT) $(1)
 bats = RESOURCES_DIR=$(RESOURCES_DIR) \
 	TIMEOUT=$(TIMEOUT) \
 	KUBEWARDEN_CRDS_CHART_OLD_VERSION=$(KUBEWARDEN_CRDS_CHART_OLD_VERSION) \
@@ -56,149 +61,70 @@ bats = RESOURCES_DIR=$(RESOURCES_DIR) \
 	NAMESPACE=$(NAMESPACE) \
 		bats --print-output-on-failure $(1)
 
-define delete-cluster =
-	- k3d cluster delete $(CLUSTER_NAME)
-endef
+helm_in = $(helm) upgrade --install --wait --namespace $(NAMESPACE) --create-namespace
 
-define create-cluster =
-	$(delete-cluster)
-	k3d cluster create $(CLUSTER_NAME) --wait --timeout $(TIMEOUT) --config $(ROOT_RESOURCES_DIR)/k3d-default.yaml -v /dev/mapper:/dev/mapper
-	$(call kube,  wait --for=condition=Ready nodes --all)
-endef
-
+# ==================================================================================================
+# Macros
 define install-kubewarden =
-	helm upgrade --install --wait \
-		--kube-context $(CLUSTER_CONTEXT) \
-		--namespace $(NAMESPACE) --create-namespace \
-		--version $(KUBEWARDEN_CRDS_CHART_VERSION) \
+	helm repo add --force-update $(KUBEWARDEN_HELM_REPO_NAME) $(KUBEWARDEN_HELM_REPO_URL)
+	$(helm_in) --version $(KUBEWARDEN_CRDS_CHART_VERSION) \
 		$(KUBEWARDEN_CRDS_CHART_RELEASE) $(KUBEWARDEN_CHARTS_LOCATION)/kubewarden-crds
-	helm upgrade --install --wait --namespace $(NAMESPACE) \
-		--kube-context $(CLUSTER_CONTEXT) \
+	$(helm_in) --version $(KUBEWARDEN_CONTROLLER_CHART_VERSION) \
 		--values $(ROOT_RESOURCES_DIR)/default-kubewarden-controller-values.yaml \
-		--version $(KUBEWARDEN_CONTROLLER_CHART_VERSION) \
 		$(KUBEWARDEN_CONTROLLER_CHART_RELEASE) $(KUBEWARDEN_CHARTS_LOCATION)/kubewarden-controller
-	helm upgrade --install --wait --namespace $(NAMESPACE) \
-		--kube-context $(CLUSTER_CONTEXT) \
+	$(helm_in) --version $(KUBEWARDEN_DEFAULTS_CHART_VERSION) \
 		--values $(ROOT_RESOURCES_DIR)/default-kubewarden-defaults-values.yaml \
-		--version $(KUBEWARDEN_DEFAULTS_CHART_VERSION) \
 		$(KUBEWARDEN_DEFAULTS_CHART_RELEASE) $(KUBEWARDEN_CHARTS_LOCATION)/kubewarden-defaults
-	$(call kube, wait --for=condition=Ready --namespace $(NAMESPACE) pods --all)
+	$(kube) wait --for=condition=Ready --namespace $(NAMESPACE) pods --all
 endef
 
 define install-cert-manager =
-	$(call kube, apply -f https://github.com/jetstack/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml)
-	$(call kube, wait --for=condition=Available deployment --timeout=$(TIMEOUT) -n cert-manager --all)
+	$(kube) apply -f https://github.com/jetstack/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml
+	$(kube) wait --for=condition=Available deployment --timeout=2m -n cert-manager --all
 endef
 
-define recreate-kubewarden-cluster
-	$(create-cluster)
-	$(install-cert-manager)
-	$(install-kubewarden)
-
-endef
-
-define generate-versioned-resources-dir
+define generate-versioned-resources-dir =
 	./scripts/generate_resources_dir.sh $(ROOT_RESOURCES_DIR) $(CRD_VERSION) $(CRD_VERSION_SUFFIX)
 endef
 
-install-k3d:
-	curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=$(K3D_VERSION) bash
+# ==================================================================================================
+# Targets
 
-install-kubewarden-chart-repo:
-	helm repo add --force-update $(KUBEWARDEN_HELM_REPO_NAME) $(KUBEWARDEN_HELM_REPO_URL)
+.PHONY: install-opentelemetry delete-opentelemetry
+install-opentelemetry:
+	$(kube) apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml
+	$(kube) wait --for=condition=Available deployment --timeout=$(TIMEOUT) -n opentelemetry-operator-system --all
 
-.PHONY: generate-versioned-resources-dir
-generate-versioned-resources-dir:
+delete-opentelemetry:
+	$(kube) delete -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml
+
+# Upgrade test requires new cluster
+upgrade.bats:: clean cluster
+	$(install-cert-manager)
+
+# Generate target for every test file
+TESTS := $(notdir $(wildcard tests/*.bats))
+$(TESTS)::
 	$(generate-versioned-resources-dir)
+	$(call bats, $(TESTS_DIR)/$@)
 
-.PHONY: setup
-setup: install-k3d install-kubewarden-chart-repo
+# Target all non-destructive tests
+.PHONY: tests
+tests: $(filter-out upgrade.bats, $(TESTS))
 
-.PHONY: install-cert-manager
-install-cert-manager:
-	$(call kube, apply -f https://github.com/jetstack/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml)
-	$(call kube, wait --for=condition=Available deployment --timeout=$(TIMEOUT) -n cert-manager --all)
+.PHONY: prepare cluster install reinstall clean
+prepare: 
+	curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
 
-.PHONY: delete-k8s-cluster
-delete-k8s-cluster:
-	$(delete-cluster)
+cluster:
+	k3d cluster create $(CLUSTER_NAME) -s 1 -a 1 --wait --timeout $(TIMEOUT) -v /dev/mapper:/dev/mapper
+	$(kube) wait --for=condition=Ready nodes --all
 
-.PHONY: create-k8s-cluster
-create-k8s-cluster: delete-k8s-cluster
-	$(create-cluster)
-
-.PHONY: install-kubewarden
-install-kubewarden: install-cert-manager install-kubewarden-chart-repo
+install:
+	$(install-cert-manager)
 	$(install-kubewarden)
 
-.PHONY: restart-kubewarden-cluster
-restart-kubewarden-cluster: 
-	$(recreate-kubewarden-cluster)
+clean:
+	k3d cluster delete $(CLUSTER_NAME)
 
-.PHONY: delete-kubewarden
-delete-kubewarden:
-	- helm --namespace $(NAMESPACE) \
-		--kube-context $(CLUSTER_CONTEXT) \
-		delete $(KUBEWARDEN_DEFAULTS_CHART_RELEASE)
-	- helm --namespace $(NAMESPACE) \
-		--kube-context $(CLUSTER_CONTEXT) \
-		delete $(KUBEWARDEN_CONTROLLER_CHART_RELEASE)
-	- helm --namespace $(NAMESPACE) \
-		--kube-context $(CLUSTER_CONTEXT) \
-		delete $(KUBEWARDEN_CRDS_CHART_RELEASE)
-
-.PHONY: delete-opentelemetry
-delete-opentelemetry:
-	$(call kube, delete -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml)
-
-.PHONY: install-opentelemetry
-install-opentelemetry: install-cert-manager
-	$(call kube, apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml)
-	$(call kube, wait --for=condition=Available deployment --timeout=$(TIMEOUT) -n opentelemetry-operator-system --all)
-
-.PHONY: reconfiguration-test
-reconfiguration-test: generate-versioned-resources-dir
-	$(call bats, $(TESTS_DIR)/reconfiguration-tests.bats)
-
-.PHONY: basic-e2e-test
-basic-e2e-test: generate-versioned-resources-dir
-	$(call bats, $(TESTS_DIR)/basic-end-to-end-tests.bats)
-
-.PHONY: mutating-requests-test
-mutating-requests-test: generate-versioned-resources-dir
-	$(call bats, $(TESTS_DIR)/mutating-requests-tests.bats)
-
-.PHONY: monitor-mode-test
-monitor-mode-test: generate-versioned-resources-dir
-	$(call bats, $(TESTS_DIR)/monitor-mode-tests.bats)
-
-.PHONY: namespaced-admission-policy-test
-namespaced-admission-policy-test: generate-versioned-resources-dir
-	$(call bats, $(TESTS_DIR)/namespaced-admission-policy-tests.bats)
-
-.PHONY: secure-supply-chain-test
-secure-supply-chain-test: generate-versioned-resources-dir
-	$(call bats, $(TESTS_DIR)/secure-supply-chain-tests.bats)
-
-.PHONY: upgrade-test
-upgrade-test: create-k8s-cluster install-kubewarden-chart-repo install-cert-manager 
-	rm -rf $(RESOURCES_DIR)
-	mkdir $(RESOURCES_DIR)
-	find $(ROOT_RESOURCES_DIR) -maxdepth 1 -type f  -exec cp \{\}  $(RESOURCES_DIR) \;
-	$(call bats, $(TESTS_DIR)/upgrade.bats)
-
-.PHONY: run-all
-run-all: install-kubewarden-chart-repo
-	$(generate-versioned-resources-dir)
-	$(recreate-kubewarden-cluster)
-	$(call bats, $(TESTS_DIR)/basic-end-to-end-tests.bats)
-	$(recreate-kubewarden-cluster)
-	$(call bats, $(TESTS_DIR)/namespaced-admission-policy-tests.bats)
-	$(recreate-kubewarden-cluster)
-	$(call bats, $(TESTS_DIR)/mutating-requests-tests.bats)
-	$(recreate-kubewarden-cluster)
-	$(call bats, $(TESTS_DIR)/secure-supply-chain-tests.bats)
-	$(recreate-kubewarden-cluster)
-	$(call bats, $(TESTS_DIR)/monitor-mode-tests.bats)
-
-
+reinstall: clean cluster install

--- a/README.md
+++ b/README.md
@@ -9,56 +9,64 @@ like yaml files to deploy Kubernetes resources.
 
 ## Requirements
 
-Most of the tests are written using [bats](https://github.com/bats-core/bats-core).
-The version used is v1.5.0. So, it's necessary install it in your environment.
+Tests are written using [bats](https://github.com/bats-core/bats-core).
+The minimal required version is v1.5.0. So, it's necessary install it in your environment.
 For that, you can check your OS packages repositories or follow the [official documentation](https://bats-core.readthedocs.io/en/stable/installation.html#installation).
 
-Other dependencies can be install with the following command:
+Other required dependencies:
 
-```console
-make setup
+```bash
+# k3d
+curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+
+# yq - python yq has different syntax then mikefarah binary
+pip3 install yq
+
+# Also kubectl, helm, docker, ...
 ```
+
+## Setting up cluster & kubewarden
+
+The Makefile has many targets to make easier to setup a test environment and
+run the tasks:
+
+```bash
+make clean   # to remove previous k3d cluster
+make cluster # to create new k3d cluster
+make install # to install kubewarden (and cert-manager)
+
+# or you can group 3 steps above into
+make reinstall
+
+# Optionally you can specify versions, see top of the Makefile for options
+KUBEWARDEN_CONTROLLER_CHART_VERSION=0.3.2 make install
+```
+
 
 ## Running the tests
 
-The Makefile has many targets to make easier to setup a test environment and
-running the tasks. You can start a K3D cluster to run your tests:
-
-```console
-make create-k8s-cluster
-```
-
-Install a given Kubewarden version:
-
-```
-make install-kubewarden
-```
-
-If you want to install a chart version different from the default one, you can
-overwrite the `KUBEWARDEN_CONTROLLER_CHART_VERSION` variable:
-
-```console
-KUBEWARDEN_CONTROLLER_CHART_VERSION=0.3.2 make install-kubewarden
-```
-
 Once you have a cluster with Kubewarden install, you can run the basic
-e2e tests:
+e2e tests.
 
-```console
-make basic-e2e-test
+```bash
+# All non-destructive tests have target auto-generated from filename
+make monitor-mode-tests.bats reconfiguration-tests.bats
+
+# There is also a target that groups all of them
+make tests
+
+# Upgrade tests is special since it reinstalls cluster
+# It does not require cluster & kubewarden setup steps
+make upgrade.bats
+
 ```
 
-You can also run the reconfiguration tests:
-
-```console
-make reconfiguration-test
-```
 
 All the tests run on a given `kubectl` context. Thus, if you want to run the
 tests on a cluster already in place, you need to define the context:
 
 ```console
-CLUSTER_CONTEXT=k3d-mycluster make basic-e2e-test
+CLUSTER_CONTEXT=k3d-mycluster make basic-end-to-end-test.bats
 ```
 
 Also check the Kubewarden controller repository to see how run this test in a [Github

--- a/resources/k3d-default.yaml
+++ b/resources/k3d-default.yaml
@@ -1,7 +1,0 @@
----
-apiVersion: k3d.io/v1alpha4
-kind: Simple
-metadata:
-  name: k3s-default
-servers: 1
-agents: 1

--- a/scripts/generate_resources_dir.sh
+++ b/scripts/generate_resources_dir.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 RESOURCES_DIR=$1
 CRD_VERSION=$2


### PR DESCRIPTION
## Description

- generate target for every testcase from filename
- simplify targets to improve readability

```bash
# create k3d cluster
make cluster

# install cert-manager & kubewarden
make install

# run test by filename or test group
make basic-end-to-end-tests.bats upgrade.bats
make tests

# install fresh kw on new cluster
make reinstall

# remove k3d cluster
make clean
```