### PR TITLE
Rewrite resource generation script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ define install-cert-manager =
 endef
 
 define generate-versioned-resources-dir =
-	./scripts/generate_resources_dir.sh $(ROOT_RESOURCES_DIR) $(CRD_VERSION) $(CRD_VERSION_SUFFIX)
+	./scripts/generate_resources_dir.sh $(ROOT_RESOURCES_DIR) $(CRD_VERSION)
 endef
 
 # ==================================================================================================


### PR DESCRIPTION
## Description

I think local scripts with `rm -r` are dangerous, so I rewrote resource generation to make it safer.

Fixes failed nightly job:
https://github.com/kubewarden/kubewarden-controller/actions/runs/3041871107/jobs/4899464494#step:5:9

## Test

https://github.com/kravciak/kubewarden-controller/actions/runs/3044096093/jobs/4904139763
