### PR TITLE
Update minimal bats version required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ like yaml files to deploy Kubernetes resources.
 ## Requirements
 
 Tests are written using [bats](https://github.com/bats-core/bats-core).
-The minimal required version is v1.5.0. So, it's necessary install it in your environment.
+The minimal required version is v1.7.0. So, it's necessary install it in your environment.
 For that, you can check your OS packages repositories or follow the [official documentation](https://bats-core.readthedocs.io/en/stable/installation.html#installation).
 
 Other required dependencies:

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-bats_require_minimum_version 1.5.0
+bats_require_minimum_version 1.7.0
 
 load "../helpers/bats-support/load.bash"
 load "../helpers/bats-assert/load.bash"


### PR DESCRIPTION
## Description

common.sh script uses the command `bats_require_minimum_version`. This command has been added in bats version v1.7.0. Therefore, it's not possible to run the tests in older bats.

