### PR TITLE
Set k3d cluster name from gh repo

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -59,15 +59,16 @@ jobs:
           policy-server-repository: ${{ inputs.policy-server-repository }}
           policy-server-tag: ${{ inputs.policy-server-tag }}
           policy-server-container-image-artifact: ${{ inputs.policy-server-container-image-artifact }}
+          cluster-name: ${{ github.repository_owner }}-ghactions-cluster
       - name: "Run all end-to-end tests"
         run: |
           make --directory e2e-tests tests upgrade.bats
         shell: bash
         env:
-          CLUSTER_CONTEXT: k3d-kubewarden-test-cluster #TODO get context from setup-kubewarden-cluster-action
+          CLUSTER_CONTEXT: k3d-${{ github.repository_owner }}-ghactions-cluster #TODO get context from setup-kubewarden-cluster-action
       - name: "Uninstall Kuberwarden"
         run: |
           # TODO - share release with the create-kubewarden-cluster action
           helm uninstall -n kubewarden kubewarden-controller kubewarden-crds kubewarden-defaults
         env:
-          HELM_KUBECONTEXT: k3d-kubewarden-test-cluster
+          HELM_KUBECONTEXT: k3d-${{ github.repository_owner }}-ghactions-cluster


### PR DESCRIPTION
## Description

Use k3d cluster name based on github repository.

Currently I have 2 runners on machine - for kravciak and kubewarden repository.
When they are running at the same time they clash and fail. This is first attempt to separate them - to easier find which one to debug.