### PR TITLE
Use newer k3s version to prevent EOF bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ tests: $(filter-out upgrade.bats, $(TESTS))
 .PHONY: cluster install reinstall clean
 
 cluster:
-	k3d cluster create $(CLUSTER_NAME) -s 1 -a 1 --wait --timeout $(TIMEOUT) -v /dev/mapper:/dev/mapper
+	k3d cluster create $(CLUSTER_NAME) -s 1 -a 1 --wait --timeout $(TIMEOUT) -v /dev/mapper:/dev/mapper --image rancher/k3s:v1.24.9-k3s2
 	$(kube) wait --for=condition=Ready nodes --all
 
 install:


### PR DESCRIPTION
Bug description https://github.com/k3s-io/k3s/issues/5835

It should fix EOF errors [e2e tests](https://github.com/kubewarden/kubewarden-controller/actions/workflows/e2e-tests.yml):
```
# Error: UPGRADE FAILED: cannot patch "no-privilege-escalation" with kind ClusterAdmissionPolicy: Internal error occurred: failed calling webhook "vclusteradmissionpolicy.kb.io": failed to call webhook: Post "https://kubewarden-controller-webhook-service.kubewarden.svc:443/validate-policies-kubewarden-io-v1-clusteradmissionpolicy?timeout=10s": EOF

# Error: UPGRADE FAILED: cannot patch "kubewarden-controller-serving-cert" with kind Certificate: Internal error occurred: failed calling webhook "webhook.cert-manager.io": failed to call webhook: Post "https://cert-manager-webhook.cert-manager.svc:443/validate?timeout=10s": EOF

# Error from server (InternalError): Internal error occurred: failed calling webhook "clusterwide-privileged-pods.kubewarden.admission": failed to call webhook: Post "https://policy-server-default.kubewarden.svc:8443/validate/clusterwide-privileged-pods?timeout=10s": EOF
```