### PR TITLE
Use same cluster name for makefile and github actions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -69,6 +69,8 @@ jobs:
       - name: "Uninstall Kuberwarden"
         run: |
           # TODO - share release with the create-kubewarden-cluster action
-          helm uninstall -n kubewarden kubewarden-defaults kubewarden-controller kubewarden-crds
+          helm uninstall --wait -n kubewarden kubewarden-defaults
+          helm uninstall --wait -n kubewarden kubewarden-controller
+          helm uninstall --wait -n kubewarden kubewarden-crds
         env:
           HELM_KUBECONTEXT: k3d-${{ github.repository_owner }}-ghactions-cluster

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -65,10 +65,10 @@ jobs:
           make --directory e2e-tests tests upgrade.bats
         shell: bash
         env:
-          CLUSTER_CONTEXT: k3d-${{ github.repository_owner }}-ghactions-cluster #TODO get context from setup-kubewarden-cluster-action
+          CLUSTER_NAME: ${{ github.repository_owner }}-ghactions-cluster
       - name: "Uninstall Kuberwarden"
         run: |
           # TODO - share release with the create-kubewarden-cluster action
-          helm uninstall -n kubewarden kubewarden-controller kubewarden-crds kubewarden-defaults
+          helm uninstall -n kubewarden kubewarden-defaults kubewarden-controller kubewarden-crds
         env:
           HELM_KUBECONTEXT: k3d-${{ github.repository_owner }}-ghactions-cluster


### PR DESCRIPTION
Cluster is created from github actions first. Then it's deleted and recreated from makefile with different name & context.
This fix reuses the same name & context also for upgrade test.

Cluster context is based on cluster name, we should be setting name variable instead:
https://github.com/kubewarden/kubewarden-end-to-end-tests/blob/main/Makefile#L42
