### PR TITLE
fix: do not need to enable telemetry in kubewarden-defaults.

### DIFF
--- a/resources/default-kubewarden-defaults-values.yaml
+++ b/resources/default-kubewarden-defaults-values.yaml
@@ -1,8 +1,6 @@
-policyServer:
+#policyServer:
 #  image:
 #    repository: "ghcr.io/myuser/policy-server"
 #    tag: "latest"
-  telemetry:
-    enabled: False
 recommendedPolicies:
   enabled: False

--- a/tests/opentelemetry-tests.bats
+++ b/tests/opentelemetry-tests.bats
@@ -31,7 +31,7 @@ setup() {
 
     # Setup Kubewarden
     helm_in kubewarden-controller --reuse-values --values $RESOURCES_DIR/opentelemetry-kw-telemetry-values.yaml
-    helm_in kubewarden-defaults --reuse-values --set policyServer.telemetry.enabled=True
+    helm_in kubewarden-defaults --reuse-values 
 }
 
 @test "[OpenTelemetry] Kubewarden containers have sidecar" {


### PR DESCRIPTION
## Description

Updates the telemetry tests removing the need to enable telemetry in the kubewarden-defaults charts. In the latest version of the Kubewarden controller the telemetry will be enable in the policy servers if the telemetry is enabled in the controller. Therefore, the field to enable this features in the kubewarden-defaults charts has been removed.

Related to https://github.com/kubewarden/helm-charts/pull/230