### PR TITLE
feat: initial audit scanner tests.

### DIFF
--- a/tests/audit-scanner-installation.bats
+++ b/tests/audit-scanner-installation.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+
+setup() {
+  load common.bash
+  wait_pods -n kube-system
+}
+
+@test "[Audit Scanner] Install with CRDs pre-installed" {
+    run kubectl api-resources
+    refute_output -p 'ClusterPolicyReport'
+    refute_output -p 'PolicyReport'
+    run kubectl get cronjob -A
+    refute_output -p audit-scanner
+
+    kubectl create -f https://github.com/kubernetes-sigs/wg-policy-prototypes/raw/master/policy-report/crd/v1alpha2/wgpolicyk8s.io_policyreports.yaml
+    kubectl create -f https://github.com/kubernetes-sigs/wg-policy-prototypes/raw/master/policy-report/crd/v1alpha2/wgpolicyk8s.io_clusterpolicyreports.yaml
+
+    helm_in kubewarden-crds  --set installPolicyReportCRDs=False
+    helm_in kubewarden-controller  --set auditScanner.enable=True
+    helm_in kubewarden-defaults  \
+        --set recommendedPolicies.enabled=True \
+        --set recommendedPolicies.defaultPolicyMode=protect \
+        --set policyServer.image.tag="latest"
+
+    run kubectl api-resources
+    assert_output -p 'ClusterPolicyReport'
+    assert_output -p 'PolicyReport'
+
+    run kubectl get cronjob -A
+    assert_output -p audit-scanner
+
+    helm_rm kubewarden-defaults
+    helm_rm kubewarden-controller
+    helm_rm kubewarden-crds
+
+    run kubectl api-resources
+    assert_output -p 'ClusterPolicyReport'
+    assert_output -p 'PolicyReport'
+    run kubectl get cronjob -A
+    refute_output -p audit-scanner
+
+    kubectl delete -f https://github.com/kubernetes-sigs/wg-policy-prototypes/raw/master/policy-report/crd/v1alpha2/wgpolicyk8s.io_policyreports.yaml
+    kubectl delete -f https://github.com/kubernetes-sigs/wg-policy-prototypes/raw/master/policy-report/crd/v1alpha2/wgpolicyk8s.io_clusterpolicyreports.yaml
+    run kubectl api-resources
+    refute_output -p 'ClusterPolicyReport'
+    refute_output -p 'PolicyReport'
+}
+
+@test "[Audit Scanner] Install with CRDs from Kubewarden Helm charts" {
+    run kubectl api-resources
+    refute_output -p 'ClusterPolicyReport'
+    refute_output -p 'PolicyReport'
+    run kubectl get cronjob -A
+    refute_output -p audit-scanner
+
+    helm_in kubewarden-crds  --set installPolicyReportCRDs=True
+    helm_in kubewarden-controller  --set auditScanner.enable=True
+    helm_in kubewarden-defaults  \
+        --set recommendedPolicies.enabled=True \
+        --set recommendedPolicies.defaultPolicyMode=protect \
+        --set policyServer.image.tag="latest"
+
+    run kubectl api-resources
+    assert_output -p 'ClusterPolicyReport'
+    assert_output -p 'PolicyReport'
+
+    run kubectl get cronjob -A
+    assert_output -p audit-scanner
+}
+
+@test "[Audit Scanner] Reconfigure audit scanner" {
+    helm_up kubewarden-controller --reuse-values --set auditScanner.cronJob.schedule="*/30 * * * *" 
+
+    run kubectl get cronjob -A
+    assert_output -p audit-scanner
+    assert_output -p "*/30 * * * *"
+}
+
+@test "[Audit Scanner] Uninstall audit scanner" {
+    helm_rm kubewarden-defaults
+    helm_rm kubewarden-controller
+    helm_rm kubewarden-crds
+
+    run kubectl api-resources
+    refute_output -p 'ClusterPolicyReport'
+    refute_output -p 'PolicyReport'
+    run kubectl get cronjob -A
+    refute_output -p audit-scanner
+}

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -23,6 +23,14 @@ function helm_in {
     return 0
 }
 
+function helm_rm {
+    helm uninstall --wait --namespace $NAMESPACE $1
+}
+
+function helm_up {
+    helm upgrade --wait --namespace $NAMESPACE "${@:2}" $1 $KUBEWARDEN_CHARTS_LOCATION/$1
+}
+
 function retry() {
     local cmd=$1
     local tries=${2:-10}


### PR DESCRIPTION
## Description

Adds the initial version of the E2E tests to validate the Audit scanner installation and reconfiguration

Add some test to address part of the issue https://github.com/kubewarden/kubewarden-controller/issues/478


## Test

```shell
make KUBEWARDEN_CHARTS_LOCATION=.<path to the latest helm chart scripts> clean cluster install-deps audit-scanner-installation.bats
```

