### PR TITLE
fix: adding missing file.

### DIFF
--- a/resources/namespace-label-propagator-policy.yaml
+++ b/resources/namespace-label-propagator-policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: policies.kubewarden.io/v1
+kind: ClusterAdmissionPolicy
+metadata:
+  name: psa-label-enforcer-policy
+spec:
+  policyServer: default
+  module: registry://ghcr.io/kubewarden/tests/psa-label-enforcer:v0.1.2
+  rules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["namespaces"]
+      operations:
+        - CREATE
+  mutating: true
+  settings:
+    modes:
+      warn: "privileged"
+      warn-version: "latest"


### PR DESCRIPTION
## Description

Adds a missing file required by the OpenTelemetry test to check if the audit scanner telemetry is working.


## Test

```console
make KUBEWARDEN_CHARTS_LOCATION=<path to latest helm chart repository version> clean cluster install audit-scanner.bats
```