### PR TITLE
Fix audit-scanner tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,9 @@ endef
 # ==================================================================================================
 # Targets
 
-# Upgrade test requires new cluster
-upgrade.bats:: clean cluster
+# Destructive tests that reinstall kubewarden
+# Test is responsible for used kubewarden version
+upgrade.bats audit-scanner-installation.bats:: clean cluster
 	$(install-cert-manager)
 
 # Generate target for every test file
@@ -104,18 +105,14 @@ $(TESTS)::
 .PHONY: tests
 tests: $(filter-out upgrade.bats audit-scanner-installation.bats, $(TESTS))
 
-.PHONY: cluster install reinstall clean install-deps
+.PHONY: cluster install reinstall clean
 
 cluster:
 	k3d cluster create $(CLUSTER_NAME) -s 1 -a 1 --wait --timeout $(TIMEOUT) -v /dev/mapper:/dev/mapper --image rancher/k3s:v1.24.12-k3s1
 	$(kube) wait --for=condition=Ready nodes --all
 
-# Target used to install dependencies. Therefore, it's possible to run tests
-# like the tests/audit-scanner-installation.bats
-install-deps:
+install:
 	$(install-cert-manager)
-
-install:  install-deps
 	$(install-kubewarden)
 
 clean:

--- a/resources/default-kubewarden-controller-values.yaml
+++ b/resources/default-kubewarden-controller-values.yaml
@@ -7,5 +7,3 @@ policyServer:
   env:
     - name: KUBEWARDEN_LOG_LEVEL
       value: debug
-auditScanner:
-  enable: true

--- a/resources/safe-labels-namespace.yaml
+++ b/resources/safe-labels-namespace.yaml
@@ -18,4 +18,3 @@ spec:
       operations:
       - CREATE
   mutating: false
-  backgroundAudit: true

--- a/resources/testing-audit-scanner-namespace.yaml
+++ b/resources/testing-audit-scanner-namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: testing-audit-scanner
-  labels:
-    cost-center: "123"

--- a/tests/audit-scanner-installation.bats
+++ b/tests/audit-scanner-installation.bats
@@ -15,8 +15,8 @@ setup() {
     kubectl create -f https://github.com/kubernetes-sigs/wg-policy-prototypes/raw/master/policy-report/crd/v1alpha2/wgpolicyk8s.io_policyreports.yaml
     kubectl create -f https://github.com/kubernetes-sigs/wg-policy-prototypes/raw/master/policy-report/crd/v1alpha2/wgpolicyk8s.io_clusterpolicyreports.yaml
 
-    helm_in kubewarden-crds  --set installPolicyReportCRDs=False
-    helm_in kubewarden-controller  --set auditScanner.enable=True
+    helm_in kubewarden-crds --set installPolicyReportCRDs=False
+    helm_in kubewarden-controller
     helm_in kubewarden-defaults  \
         --set recommendedPolicies.enabled=True \
         --set recommendedPolicies.defaultPolicyMode=protect \
@@ -53,8 +53,8 @@ setup() {
     run kubectl get cronjob -A
     refute_output -p audit-scanner
 
-    helm_in kubewarden-crds  --set installPolicyReportCRDs=True
-    helm_in kubewarden-controller  --set auditScanner.enable=True
+    helm_in kubewarden-crds # defaults to installPolicyReportCRDs=True
+    helm_in kubewarden-controller
     helm_in kubewarden-defaults  \
         --set recommendedPolicies.enabled=True \
         --set recommendedPolicies.defaultPolicyMode=protect \

--- a/tests/audit-scanner.bats
+++ b/tests/audit-scanner.bats
@@ -6,25 +6,25 @@ setup() {
 }
 
 @test "[Audit Scanner] Install testing policies and resources" {
-	run kubectl get cronjob -A
-	assert_output -p audit-scanner
+    # Make sure cronjob was created
+    kubectl get cronjob -n kubewarden audit-scanner
 
-	# Launch unprivileged pod
-	kubectl run nginx-unprivileged --image=nginx:alpine
-	kubectl wait --for=condition=Ready pod nginx-unprivileged
+    # Launch unprivileged pod
+    kubectl run nginx-unprivileged --image=nginx:alpine
+    kubectl wait --for=condition=Ready pod nginx-unprivileged
 
-	# Launch privileged pod
-	kubectl run nginx-privileged --image=registry.k8s.io/pause --privileged
-	kubectl wait --for=condition=Ready pod nginx-privileged
+    # Launch privileged pod
+    kubectl run nginx-privileged --image=registry.k8s.io/pause --privileged
+    kubectl wait --for=condition=Ready pod nginx-privileged
 
-	# Create a namespace to trigger a fail evaluation in the audit scanner
-	kubectl apply -f $RESOURCES_DIR/testing-audit-scanner-namespace.yaml
+    # Create a namespace to trigger a fail evaluation in the audit scanner
+    kubectl create ns testing-audit-scanner
+    kubectl label ns testing-audit-scanner cost-center=123
 
-	# Deploy some policy
-	apply_cluster_admission_policy $RESOURCES_DIR/privileged-pod-policy.yaml
-	apply_cluster_admission_policy $RESOURCES_DIR/namespace-psa-label-enforcer-policy.yaml
-	apply_cluster_admission_policy $RESOURCES_DIR/safe-labels-namespace.yaml
-
+    # Deploy some policy
+    apply_cluster_admission_policy $RESOURCES_DIR/privileged-pod-policy.yaml
+    apply_cluster_admission_policy $RESOURCES_DIR/namespace-psa-label-enforcer-policy.yaml
+    apply_cluster_admission_policy $RESOURCES_DIR/safe-labels-namespace.yaml
 }
 
 @test "[Audit Scanner] Trigger audit scanner job" {
@@ -37,27 +37,25 @@ setup() {
 }
 
 @test "[Audit Scanner] Check cluster wide report results" {
-    retry "kubectl get clusterpolicyreports -o json | jq -e '[.items[].metadata.name == \"polr-clusterwide\"] | any'"
-    retry "kubectl get clusterpolicyreports polr-clusterwide -o json | jq -e '[.summary.pass == 13] | all'" #1
-    retry "kubectl get clusterpolicyreports polr-clusterwide -o json | jq -e '[.summary.fail == 1] | all'" #1
-    retry "kubectl get clusterpolicyreports polr-clusterwide -o json | jq -e '[.results[] | select(.resources[0].name==\"default\") | .result==\"pass\"] | all'"
-    retry "kubectl get clusterpolicyreports polr-clusterwide -o json | jq -e '[.results[] | select(.resources[0].name == \"testing-audit-scanner\" and .policy == \"cap-safe-labels\")] | all(.result == \"fail\")'"
+    local report=$(kubectl get clusterpolicyreports polr-clusterwide -o json | jq -ec)
+    echo "$report" | jq -e '.summary.pass == 13'
+    echo "$report" | jq -e '.summary.fail == 1'
+    echo "$report" | jq -e '[.results[] | select(.resources[0].name=="default") | .result=="pass"] | all'
+    echo "$report" | jq -e '[.results[] | select(.resources[0].name == "testing-audit-scanner" and .policy == "cap-safe-labels")] | all(.result == "fail")'
 }
 
 @test "[Audit Scanner] Check namespaced report results" {
-    retry "kubectl get policyreports -o json | jq -e '[.items[].metadata.name == \"polr-ns-default\"] | any'"
-    retry "kubectl get policyreports polr-ns-default -o json | jq -e '[.summary.fail == 1] | all'"
-    retry "kubectl get policyreports polr-ns-default -o json | jq -e '[.summary.pass == 1] | all'"
-
-    retry "kubectl get policyreports polr-ns-default -o json | jq -e '[.results[] | select(.resources[0].name==\"nginx-unprivileged\") | .result==\"pass\"] | all'"
-    retry "kubectl get policyreports polr-ns-default -o json | jq -e '[.results[] | select(.resources[0].name==\"nginx-privileged\") | .result==\"fail\"] | all'"
+    local report=$(kubectl get policyreports polr-ns-default -o json | jq -ec)
+    echo "$report" | jq -e '.summary.fail == 1'
+    echo "$report" | jq -e '.summary.pass == 1'
+    echo "$report" | jq -e '[.results[] | select(.resources[0].name=="nginx-unprivileged") | .result=="pass"] | all'
+    echo "$report" | jq -e '[.results[] | select(.resources[0].name=="nginx-privileged") | .result=="fail"] | all'
 }
 
 teardown_file() {
     kubectl delete --wait -f $RESOURCES_DIR/privileged-pod-policy.yaml
     kubectl delete --wait -f $RESOURCES_DIR/namespace-label-propagator-policy.yaml
     kubectl delete --wait -f $RESOURCES_DIR/safe-labels-namespace.yaml
-    kubectl delete --wait -f $RESOURCES_DIR/testing-audit-scanner-namespace.yaml
-    kubectl delete --wait pod nginx-privileged
-    kubectl delete --wait pod nginx-unprivileged
+    kubectl delete ns testing-audit-scanner
+    kubectl delete --wait pod nginx-privileged nginx-unprivileged
 }

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -13,8 +13,10 @@ function helm() {
 	command helm --kube-context $CLUSTER_CONTEXT "$@"
 }
 
-function helm_in {
-    helm upgrade --install --wait --namespace $NAMESPACE --create-namespace \
+# Upgrade helm chart, but won't install if it does not exist
+function helm_up {
+    helm upgrade --devel --wait \
+        --namespace $NAMESPACE --create-namespace \
         "${@:2}" $1 $KUBEWARDEN_CHARTS_LOCATION/$1
 
     # kubewarden-defaults ignore wait param, so rollout status would fail without retry (does not exist yet)
@@ -27,8 +29,9 @@ function helm_rm {
     helm uninstall --wait --namespace $NAMESPACE $1
 }
 
-function helm_up {
-    helm upgrade --wait --namespace $NAMESPACE "${@:2}" $1 $KUBEWARDEN_CHARTS_LOCATION/$1
+# Install or upgrade helm chart
+function helm_in {
+    helm_up $@ --install
 }
 
 function retry() {

--- a/tests/opentelemetry-tests.bats
+++ b/tests/opentelemetry-tests.bats
@@ -30,8 +30,8 @@ setup() {
     wait_pods -n jaeger
 
     # Setup Kubewarden
-    helm_in kubewarden-controller --reuse-values --values $RESOURCES_DIR/opentelemetry-kw-telemetry-values.yaml
-    helm_in kubewarden-defaults --reuse-values --set "recommendedPolicies.enabled=True"
+    helm_up kubewarden-controller --reuse-values --values $RESOURCES_DIR/opentelemetry-kw-telemetry-values.yaml
+    helm_up kubewarden-defaults --reuse-values --set "recommendedPolicies.enabled=True"
 
 }
 
@@ -93,8 +93,8 @@ setup() {
 
 
 @test "[OpenTelemetry] User should be able to disable telemetry" {
-    helm_in kubewarden-controller --reuse-values --values $RESOURCES_DIR/opentelemetry-kw-telemetry-values.yaml --set "telemetry.enabled=False"
-    helm_in kubewarden-defaults --reuse-values
+    helm_up kubewarden-controller --reuse-values --values $RESOURCES_DIR/opentelemetry-kw-telemetry-values.yaml --set "telemetry.enabled=False"
+    helm_up kubewarden-defaults --reuse-values
 }
 
 @test "[OpenTelemetry] Kubewarden containers have no sidecar" {

--- a/tests/private-registry-tests.bats
+++ b/tests/private-registry-tests.bats
@@ -15,7 +15,7 @@ teardown_file() {
 	load common.bash
 	kubectl delete clusteradmissionpolicies private-pod-privileged ||:
 
-	helm_in kubewarden-defaults --reuse-values \
+	helm_up kubewarden-defaults --reuse-values \
 		--set policyServer.imagePullSecret=null \
 		--set policyServer.sourceAuthorities=null
 	# Can't delete secret - https://github.com/kubewarden/policy-server/issues/459
@@ -83,7 +83,7 @@ teardown_file() {
 	  --docker-server=$REGISTRY
 
 	# Edit default policy server config
-	helm_in kubewarden-defaults --reuse-values \
+	helm_up kubewarden-defaults --reuse-values \
 		--set policyServer.imagePullSecret=secret-registry-docker \
 		--set policyServer.sourceAuthorities[0].uri="$REGISTRY" \
 		--set-file policyServer.sourceAuthorities[0].certs[0]="$BATS_RUN_TMPDIR/certs/rootCA.crt"

--- a/tests/reconfiguration-tests.bats
+++ b/tests/reconfiguration-tests.bats
@@ -15,9 +15,7 @@ teardown_file() {
 }
 
 @test "[Reconfiguration tests] Reconfigure Kubewarden stack" {
-	helm upgrade --wait --namespace $NAMESPACE --reuse-values  \
-		--values=$RESOURCES_DIR/reconfiguration-values.yaml \
-		$KUBEWARDEN_CONTROLLER_CHART_RELEASE $CONTROLLER_CHART
+	helm_up kubewarden-controller --reuse-values --values=$RESOURCES_DIR/reconfiguration-values.yaml
 	wait_for_cluster_admission_policy PolicyActive
 }
 

--- a/tests/secure-supply-chain-tests.bats
+++ b/tests/secure-supply-chain-tests.bats
@@ -17,7 +17,7 @@ setup() {
 }
 
 teardown_file() {
-	helm upgrade -n kubewarden --set policyServer.verificationConfig="" --wait kubewarden-defaults kubewarden/kubewarden-defaults
+	helm_up kubewarden-defaults --set policyServer.verificationConfig=""
 	kubectl delete configmap -n $NAMESPACE $CONFIGMAP_NAME --ignore-not-found
 }
 
@@ -41,7 +41,7 @@ function get_policy_server_status {
 @test "[Secure Supply Chain tests] Enable" {
 	# policyserver needs configmap to start in verification mode
 	create_configmap <(kwctl scaffold verification-config)
-	helm_in kubewarden-defaults --set policyServer.verificationConfig=$CONFIGMAP_NAME
+	helm_up kubewarden-defaults --set policyServer.verificationConfig=$CONFIGMAP_NAME
 	kubectl get policyserver default -o json | jq -e --arg cmname $CONFIGMAP_NAME '.spec.verificationConfig == $cmname'
 }
 

--- a/tests/upgrade.bats
+++ b/tests/upgrade.bats
@@ -39,9 +39,9 @@ function check_default_policies {
 }
 
 @test "[CRD upgrade] Upgrade Kubewarden" {
-    helm_in kubewarden-crds --version $KUBEWARDEN_CRDS_CHART_VERSION
-    helm_in kubewarden-controller --version $KUBEWARDEN_CONTROLLER_CHART_VERSION
-    helm_in kubewarden-defaults --version $KUBEWARDEN_DEFAULTS_CHART_VERSION
+    helm_up kubewarden-crds --version $KUBEWARDEN_CRDS_CHART_VERSION
+    helm_up kubewarden-controller --version $KUBEWARDEN_CONTROLLER_CHART_VERSION
+    helm_up kubewarden-defaults --version $KUBEWARDEN_DEFAULTS_CHART_VERSION
     check_default_policies
 }
 
@@ -52,7 +52,7 @@ function check_default_policies {
 }
 
 @test "[CRD upgrade] Disable default policies & run privileged pod" {
-	helm_in kubewarden-defaults --set recommendedPolicies.enabled=False
+	helm_up kubewarden-defaults --set recommendedPolicies.enabled=False
 	wait_rollout -n $NAMESPACE "deployment/policy-server-default"
 	kubectl run pod-privileged --image=registry.k8s.io/pause --privileged
 }


### PR DESCRIPTION
- simplify Makefile
- remove retries
- remove explicit enable of audit scanner, it should be enabled by default
- add `--devel` option to helm commands since we use it during main installation