### PR TITLE
Improve e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -62,7 +62,7 @@ jobs:
           cluster-name: ${{ github.repository_owner }}-ghactions-cluster
       - name: "Run all end-to-end tests"
         run: |
-          make --directory e2e-tests tests upgrade.bats audit-scanner-installation.bats
+          make --directory e2e-tests tests audit-scanner-installation.bats upgrade.bats
         shell: bash
         env:
           CLUSTER_NAME: ${{ github.repository_owner }}-ghactions-cluster

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,8 @@ endef
 
 # Destructive tests that reinstall kubewarden
 # Test is responsible for used kubewarden version
-upgrade.bats audit-scanner-installation.bats:: clean cluster
+upgrade.bats::
+	$(MAKE) clean cluster
 	$(install-cert-manager)
 
 # Generate target for every test file

--- a/tests/audit-scanner-installation.bats
+++ b/tests/audit-scanner-installation.bats
@@ -5,83 +5,75 @@ setup() {
   wait_pods -n kube-system
 }
 
-@test "[Audit Scanner] Install with CRDs pre-installed" {
+CRD_BASE=https://github.com/kubernetes-sigs/wg-policy-prototypes/raw/master/policy-report/crd/v1alpha2/
+
+# assert_crds true|false
+function assert_crds {
     run kubectl api-resources
-    refute_output -p 'ClusterPolicyReport'
-    refute_output -p 'PolicyReport'
-    run kubectl get cronjob -A
-    refute_output -p audit-scanner
-
-    kubectl create -f https://github.com/kubernetes-sigs/wg-policy-prototypes/raw/master/policy-report/crd/v1alpha2/wgpolicyk8s.io_policyreports.yaml
-    kubectl create -f https://github.com/kubernetes-sigs/wg-policy-prototypes/raw/master/policy-report/crd/v1alpha2/wgpolicyk8s.io_clusterpolicyreports.yaml
-
-    helm_in kubewarden-crds --set installPolicyReportCRDs=False
-    helm_in kubewarden-controller
-    helm_in kubewarden-defaults  \
-        --set recommendedPolicies.enabled=True \
-        --set recommendedPolicies.defaultPolicyMode=protect
-
-    run kubectl api-resources
-    assert_output -p 'ClusterPolicyReport'
-    assert_output -p 'PolicyReport'
-
-    run kubectl get cronjob -A
-    assert_output -p audit-scanner
-
-    helm_rm kubewarden-defaults
-    helm_rm kubewarden-controller
-    helm_rm kubewarden-crds
-
-    run kubectl api-resources
-    assert_output -p 'ClusterPolicyReport'
-    assert_output -p 'PolicyReport'
-    run kubectl get cronjob -A
-    refute_output -p audit-scanner
-
-    kubectl delete -f https://github.com/kubernetes-sigs/wg-policy-prototypes/raw/master/policy-report/crd/v1alpha2/wgpolicyk8s.io_policyreports.yaml
-    kubectl delete -f https://github.com/kubernetes-sigs/wg-policy-prototypes/raw/master/policy-report/crd/v1alpha2/wgpolicyk8s.io_clusterpolicyreports.yaml
-    run kubectl api-resources
-    refute_output -p 'ClusterPolicyReport'
-    refute_output -p 'PolicyReport'
+    if $1; then
+        assert_output -p 'ClusterPolicyReport'
+        assert_output -p 'PolicyReport'
+    else
+        refute_output -p 'ClusterPolicyReport'
+        refute_output -p 'PolicyReport'
+    fi
 }
 
-@test "[Audit Scanner] Install with CRDs from Kubewarden Helm charts" {
-    run kubectl api-resources
-    refute_output -p 'ClusterPolicyReport'
-    refute_output -p 'PolicyReport'
-    run kubectl get cronjob -A
-    refute_output -p audit-scanner
-
-    helm_in kubewarden-crds # defaults to installPolicyReportCRDs=True
-    helm_in kubewarden-controller
-    helm_in kubewarden-defaults  \
-        --set recommendedPolicies.enabled=True \
-        --set recommendedPolicies.defaultPolicyMode=protect
-
-    run kubectl api-resources
-    assert_output -p 'ClusterPolicyReport'
-    assert_output -p 'PolicyReport'
-
-    run kubectl get cronjob -A
-    assert_output -p audit-scanner
+# assert_cronjob true|false
+function assert_cronjob {
+    run kubectl get cronjob -n $NAMESPACE
+    if $1; then
+        assert_output -p audit-scanner
+    else
+        refute_output -p audit-scanner
+    fi
 }
 
 @test "[Audit Scanner] Reconfigure audit scanner" {
     helm_up kubewarden-controller --reuse-values --set auditScanner.cronJob.schedule="*/30 * * * *" 
-
-    run kubectl get cronjob -A
+    run kubectl get cronjob -n $NAMESPACE
     assert_output -p audit-scanner
     assert_output -p "*/30 * * * *"
 }
 
-@test "[Audit Scanner] Uninstall audit scanner" {
-    helm_rm kubewarden-defaults
-    helm_rm kubewarden-controller
-    helm_rm kubewarden-crds
+@test "[Audit Scanner] Audit scanner resources are cleaned with kubewarden" {
+    kubewarden_remove
+    assert_crds false
+    assert_cronjob false
+}
 
-    run kubectl api-resources
-    refute_output -p 'ClusterPolicyReport'
-    refute_output -p 'PolicyReport'
-    run kubectl get cronjob -A
-    refute_output -p audit-scanner
+@test "[Audit Scanner] Install with CRDs pre-installed" {
+    # Install kubewarden with custom policyreport-crds
+    kubectl create -f $CRD_BASE/wgpolicyk8s.io_policyreports.yaml
+    kubectl create -f $CRD_BASE/wgpolicyk8s.io_clusterpolicyreports.yaml
+    assert_crds true
+
+    # Install kubewarden with existing policyreport crds
+    helm_in kubewarden-crds --set installPolicyReportCRDs=False
+    helm_in kubewarden-controller
+    assert_cronjob true
+
+    # Check policy reports did not come from helm (have no labels)
+    kubectl get crds policyreports.wgpolicyk8s.io -o json | jq -e '.metadata.labels == null'
+    kubectl get crds clusterpolicyreports.wgpolicyk8s.io -o json | jq -e '.metadata.labels == null'
+
+    # Kubewarden should not remove custom crds
+    kubewarden_remove
+    assert_crds true
+    assert_cronjob false
+
+    kubectl delete -f $CRD_BASE/wgpolicyk8s.io_policyreports.yaml
+    kubectl delete -f $CRD_BASE/wgpolicyk8s.io_clusterpolicyreports.yaml
+    assert_crds false
+}
+
+@test "[Audit Scanner] Install with CRDs from Kubewarden Helm charts" {
+    helm_in kubewarden-crds
+    helm_in kubewarden-controller
+    assert_crds true
+    assert_cronjob true
+
+    # Check crds were installed by helm
+    kubectl get crds policyreports.wgpolicyk8s.io --show-labels | grep 'managed-by=Helm'
+    kubectl get crds clusterpolicyreports.wgpolicyk8s.io --show-labels | grep 'managed-by=Helm'
 }

--- a/tests/audit-scanner.bats
+++ b/tests/audit-scanner.bats
@@ -28,12 +28,9 @@ setup() {
 }
 
 @test "[Audit Scanner] Trigger audit scanner job" {
-    run kubectl get jobs -A
-    refute_output -p 'testing'
-
     run kubectl create job  --from=cronjob/audit-scanner testing  --namespace $NAMESPACE
     assert_output -p "testing created"
-    run kubectl wait --for=condition="Complete" job testing --namespace $NAMESPACE
+    kubectl wait --for=condition="Complete" job testing --namespace $NAMESPACE
 }
 
 @test "[Audit Scanner] Check cluster wide report results" {
@@ -53,9 +50,10 @@ setup() {
 }
 
 teardown_file() {
-    kubectl delete --wait -f $RESOURCES_DIR/privileged-pod-policy.yaml
-    kubectl delete --wait -f $RESOURCES_DIR/namespace-label-propagator-policy.yaml
-    kubectl delete --wait -f $RESOURCES_DIR/safe-labels-namespace.yaml
+    kubectl delete -f $RESOURCES_DIR/privileged-pod-policy.yaml
+    kubectl delete -f $RESOURCES_DIR/namespace-label-propagator-policy.yaml
+    kubectl delete -f $RESOURCES_DIR/safe-labels-namespace.yaml
     kubectl delete ns testing-audit-scanner
-    kubectl delete --wait pod nginx-privileged nginx-unprivileged
+    kubectl delete pod nginx-privileged nginx-unprivileged
+    kubectl delete jobs -n kubewarden testing
 }

--- a/tests/opentelemetry-tests.bats
+++ b/tests/opentelemetry-tests.bats
@@ -35,41 +35,34 @@ setup() {
 
 }
 
-@test "[OpenTelemetry] Kubewarden containers have sidecar" {
-    # Controller needs to be restarted to get sidecar
+@test "[OpenTelemetry] Kubewarden containers have sidecars & metrics" {
+    # Controller is restarted to get sidecar
     wait_pods -n kubewarden
 
     # Check all pods have sidecar (otc-container) - might take a minute to start
-    retry "kubectl get pods -n kubewarden -o json | jq -e '[.items[].spec.containers[1].name == \"otc-container\"] | all'"
-}
+    retry "kubectl get pods -n kubewarden --field-selector=status.phase==Running -o json | jq -e '[.items[].spec.containers[1].name == \"otc-container\"] | all'"
+    # Policy server service has the metrics ports
+    kubectl get services -n kubewarden  policy-server-default -o json | jq -e '[.spec.ports[].name == "metrics"] | any'
+    # Controller service has the metrics ports
+    kubectl get services -n kubewarden kubewarden-controller-metrics-service -o json | jq -e '[.spec.ports[].name == "metrics"] | any'
 
-@test "[OpenTelemetry] Policy server service has the metrics ports" {
-	retry "kubectl get services -n kubewarden  policy-server-default -o json | jq -e '[.spec.ports[].name == \"metrics\"] | any '"
-}
-
-@test "[OpenTelemetry] Controller service has the metrics ports" {
-	retry "kubectl get services -n kubewarden kubewarden-controller-metrics-service -o json | jq -e '[.spec.ports[].name == \"metrics\"] | any '"
-}
-
-@test "[OpenTelemetry] Policy server metrics should be available" {
     # Generate metric data
     kubectl run pod-privileged --image=registry.k8s.io/pause --privileged
-    retry "[ \$(kubectl delete --ignore-not-found pod get-policy-server-metric; kubectl run get-policy-server-metric -t -i --rm --wait --image curlimages/curl:8.00.1 --restart=Never -- --silent policy-server-default.kubewarden.svc.cluster.local:8080/metrics | wc -l ) -gt 10 ] || exit 1"
+    kubectl wait --for=condition=Ready pod pod-privileged
+    kubectl delete --wait pod pod-privileged
+
+    # Policy server metrics should be available
+    test $(curlpod --silent policy-server-default.kubewarden.svc.cluster.local:8080/metrics | wc -l ) -gt 10
+    # Controller metrics should be available
+    test $(curlpod --silent kubewarden-controller-metrics-service.kubewarden.svc.cluster.local:8080/metrics | wc -l) -gt 1
 }
 
-@test "[OpenTelemetry] Controller metrics should be available" {
-    retry "[ \$(kubectl delete --ignore-not-found pod get-controller-metric; kubectl run get-controller-metric -t -i --rm --wait --image curlimages/curl:8.00.1 --restart=Never -- --silent kubewarden-controller-metrics-service.kubewarden.svc.cluster.local:8080/metrics | wc -l) -gt 1 ] || exit 1"
-}
+@test "[OpenTelemetry] Audit scanner runs should generate metrics" {
+    kubectl get cronjob -n $NAMESPACE audit-scanner
 
-@test "[OpenTelemtry] Audit scanner runs should generate metrics" {
-    run kubectl get cronjob -A
-    assert_output -p audit-scanner
-
-    # Launch unprivileged pod
+    # Launch unprivileged & privileged pods
     kubectl run nginx-unprivileged --image=nginx:alpine
     kubectl wait --for=condition=Ready pod nginx-unprivileged
-
-    # Launch privileged pod
     kubectl run nginx-privileged --image=registry.k8s.io/pause --privileged
     kubectl wait --for=condition=Ready pod nginx-privileged
 
@@ -77,38 +70,31 @@ setup() {
     apply_cluster_admission_policy $RESOURCES_DIR/privileged-pod-policy.yaml
     apply_cluster_admission_policy $RESOURCES_DIR/namespace-label-propagator-policy.yaml
 
-    run kubectl get jobs -A
-    refute_output -p 'testing'
-
     run kubectl create job  --from=cronjob/audit-scanner testing  --namespace $NAMESPACE
     assert_output -p "testing created"
+    kubectl wait --for=condition="Complete" job testing --namespace $NAMESPACE
 
-    retry "kubectl get clusterpolicyreports -o json | jq -e '[.items[].metadata.name == \"polr-clusterwide\"] | any'"
-    retry "kubectl get policyreports -o json | jq -e '[.items[].metadata.name == \"polr-ns-default\"] | any'"
-    retry "[ \$(kubectl delete --ignore-not-found pod get-policy-server-metric; kubectl run get-policy-server-metric -t -i --rm --wait --image curlimages/curl:8.00.1 --restart=Never -- --silent policy-server-default.kubewarden.svc.cluster.local:8080/metrics |  grep protect | sed --silent  's/.*policy_name=\(.*\).*/\1/p' | sed 's/,.*//p' | sort -u | wc -l) -eq 2 ] || exit 1"
-
-    kubectl delete --wait -f $RESOURCES_DIR/privileged-pod-policy.yaml
-    kubectl delete --wait -f $RESOURCES_DIR/namespace-label-propagator-policy.yaml
+    kubectl get clusterpolicyreports polr-clusterwide
+    kubectl get policyreports polr-ns-default
+    test $(curlpod --silent policy-server-default.kubewarden.svc.cluster.local:8080/metrics | grep protect | sed --silent  's/.*policy_name=\(.*\).*/\1/p' | sed 's/,.*//p' | sort -u | wc -l) -eq 2
 }
 
-
-@test "[OpenTelemetry] User should be able to disable telemetry" {
+@test "[OpenTelemetry] Disabling telemetry should remove sidecars & metrics" {
     helm_up kubewarden-controller --reuse-values --values $RESOURCES_DIR/opentelemetry-kw-telemetry-values.yaml --set "telemetry.enabled=False"
     helm_up kubewarden-defaults --reuse-values
-}
-
-@test "[OpenTelemetry] Kubewarden containers have no sidecar" {
-    # Controller needs to be restarted to get sidecar
     wait_pods -n kubewarden
 
     # Check sidecars (otc-container) - have been removed
     retry "kubectl get pods -n kubewarden -o json | jq -e '[.items[].spec.containers[1].name != \"otc-container\"] | all'"
+    # Policy server service has no metrics ports
+    kubectl get services -n kubewarden policy-server-default -o json | jq -e '[.spec.ports[].name != "metrics"] | all'
+    # Controller service has no metrics ports
+    kubectl get services -n kubewarden kubewarden-controller-metrics-service -o json | jq -e '[.spec.ports[].name != "metrics"] | all '
 }
 
-@test "[OpenTelemetry] Policy server service has no metrics ports" {
-	retry "kubectl get services -n kubewarden  policy-server-default -o json | jq -e '[.spec.ports[].name != \"metrics\"] | all '"
-}
-
-@test "[OpenTelemetry] Controller service has no metrics ports" {
-	retry "kubectl get services -n kubewarden kubewarden-controller-metrics-service -o json | jq -e '[.spec.ports[].name != \"metrics\"] | all '"
+teardown_file() {
+    kubectl delete -f $RESOURCES_DIR/privileged-pod-policy.yaml
+    kubectl delete -f $RESOURCES_DIR/namespace-label-propagator-policy.yaml
+    kubectl delete pod nginx-privileged nginx-unprivileged
+    kubectl delete jobs -n kubewarden testing
 }

--- a/tests/upgrade.bats
+++ b/tests/upgrade.bats
@@ -39,9 +39,9 @@ function check_default_policies {
 }
 
 @test "[CRD upgrade] Upgrade Kubewarden" {
-    helm_up kubewarden-crds --version $KUBEWARDEN_CRDS_CHART_VERSION
-    helm_up kubewarden-controller --version $KUBEWARDEN_CONTROLLER_CHART_VERSION
-    helm_up kubewarden-defaults --version $KUBEWARDEN_DEFAULTS_CHART_VERSION
+    helm_up kubewarden-crds --reuse-values --version $KUBEWARDEN_CRDS_CHART_VERSION
+    helm_up kubewarden-controller --reuse-values --version $KUBEWARDEN_CONTROLLER_CHART_VERSION
+    helm_up kubewarden-defaults --reuse-values --version $KUBEWARDEN_DEFAULTS_CHART_VERSION
     check_default_policies
 }
 


### PR DESCRIPTION
- pass chart versions from makefile to helm_in and helm_up commands
- simplify audit scanner installation test
- properly cleanup leftovers from audit scanner test
- add `curlpod` function that calls curl from in pod
- remove retries where it's not needed
- reorganize opentelemetry code to not call single operation per test
- use --reuse parameter for helm upgrade

If you want to run locally before rc2 you need to use `auditScanner.image.tag=latest` parameter and symlink charts directory into e2e tests.

```bash
KUBEWARDEN_CHARTS_LOCATION=./charts make clean cluster install tests audit-scanner-installation.bats
```

```diff
diff --git a/Makefile b/Makefile
index 734ef27..8a1ee33 100644
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ define install-kubewarden =
                $(KUBEWARDEN_CRDS_CHART_RELEASE) $(KUBEWARDEN_CHARTS_LOCATION)/kubewarden-crds
        $(helm_in) --version $(KUBEWARDEN_CONTROLLER_CHART_VERSION) \
                --values $(ROOT_RESOURCES_DIR)/default-kubewarden-controller-values.yaml \
-               $(KUBEWARDEN_CONTROLLER_CHART_RELEASE) $(KUBEWARDEN_CHARTS_LOCATION)/kubewarden-controller
+               $(KUBEWARDEN_CONTROLLER_CHART_RELEASE) $(KUBEWARDEN_CHARTS_LOCATION)/kubewarden-controller --set auditScanner.image.tag=latest
        $(helm_in) --version $(KUBEWARDEN_DEFAULTS_CHART_VERSION) \
                --values $(ROOT_RESOURCES_DIR)/default-kubewarden-defaults-values.yaml \
                $(KUBEWARDEN_DEFAULTS_CHART_RELEASE) $(KUBEWARDEN_CHARTS_LOCATION)/kubewarden-defaults
diff --git a/tests/common.bash b/tests/common.bash
index 827dc5a..f824913 100644
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -22,6 +22,7 @@ function helm_up {
     # set default version, can be overridden with parameters
     case $1 in
         'kubewarden-controller')
+            extraparams='--set auditScanner.image.tag=latest'
             def_version=$KUBEWARDEN_CRDS_CHART_VERSION;;
         'kubewarden-defaults')
             def_version=$KUBEWARDEN_DEFAULTS_CHART_VERSION;;
@@ -31,7 +32,7 @@ function helm_up {
 
     helm upgrade --version $def_version --wait \
         --namespace $NAMESPACE --create-namespace \
-        "${@:2}" $1 $KUBEWARDEN_CHARTS_LOCATION/$1
+        "${@:2}" $1 $KUBEWARDEN_CHARTS_LOCATION/$1 ${extraparams:-}

```