### PR TITLE
Fix kubewarden controller version parameter

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -22,7 +22,7 @@ function helm_up {
     # set default version, can be overridden with parameters
     case $1 in
         'kubewarden-controller')
-            def_version=$KUBEWARDEN_CRDS_CHART_VERSION;;
+            def_version=$KUBEWARDEN_CONTROLLER_CHART_VERSION;;
         'kubewarden-defaults')
             def_version=$KUBEWARDEN_DEFAULTS_CHART_VERSION;;
         'kubewarden-crds')


### PR DESCRIPTION
Fix for failing audit scanner test:
```
 [Audit Scanner] Reconfigure audit scanner [timeout: 5m]
   (from function `helm' in file tests/common.bash, line 13,
    from function `helm_up' in file tests/common.bash, line 32,
    in test file tests/audit-scanner-installation.bats, line 33)
     `helm_up kubewarden-controller --reuse-values --set auditScanner.cronJob.schedule="*/30 * * * *" ' failed
   Error: chart "kubewarden-controller" matching 1.4.0-rc2 not found in kubewarden index. (try 'helm repo update'): no chart version found for kubewarden-controller-1.4.0-rc2
```