### PR TITLE
Fix controller e2e nightly tests

### DIFF
--- a/tests/audit-scanner.bats
+++ b/tests/audit-scanner.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  load common.bash
-  wait_pods -n kube-system
+    load common.bash
+    wait_pods -n kube-system
 }
 
 @test "[Audit Scanner] Install testing policies and resources" {
@@ -35,7 +35,8 @@ setup() {
 
 @test "[Audit Scanner] Check cluster wide report results" {
     local report=$(kubectl get clusterpolicyreports polr-clusterwide -o json | jq -ec)
-    echo "$report" | jq -e '.summary.pass == 13'
+    # clean cluster = 13, but recommended policies or other resources can increase this
+    echo "$report" | jq -e '.summary.pass >= 13'
     echo "$report" | jq -e '.summary.fail == 1'
     echo "$report" | jq -e '[.results[] | select(.resources[0].name=="default") | .result=="pass"] | all'
     echo "$report" | jq -e '[.results[] | select(.resources[0].name == "testing-audit-scanner" and .policy == "cap-safe-labels")] | all(.result == "fail")'

--- a/tests/reconfiguration-tests.bats
+++ b/tests/reconfiguration-tests.bats
@@ -15,7 +15,7 @@ teardown_file() {
 }
 
 @test "[Reconfiguration tests] Reconfigure Kubewarden stack" {
-	helm_up kubewarden-controller --reuse-values --values=$RESOURCES_DIR/reconfiguration-values.yaml
+	helm_up kubewarden-controller --values=$RESOURCES_DIR/reconfiguration-values.yaml
 	wait_for_cluster_admission_policy PolicyActive
 }
 


### PR DESCRIPTION
Fix e2e nightly tests
 - audit scanner test espects `13` passed and `1` failed records. Recommended policies and other resources can change this count.
 https://github.com/kravciak/kubewarden-controller/actions/runs/6081948684/job/16498773182
 This check seems quite fragile, should be changed into something more stable.
 - remove `--reuse-values` flag for nil pointer interface failures:
 https://github.com/kubewarden/kubewarden-controller/actions/runs/6067546534/job/16459389883

Local run: https://github.com/kravciak/kubewarden-controller/actions/runs/6084147639/job/16505541684