### PR TITLE
Use context in retry commands

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -35,7 +35,7 @@ function helm_up {
 
     # kubewarden-defaults ignore wait param, so rollout status would fail without retry (does not exist yet)
     # retry function requires full command, not a function
-    [ $1 = 'kubewarden-defaults' ] && retry "kubectl --context $CLUSTER_CONTEXT rollout status -n kubewarden deployment/policy-server-default"
+    [ $1 = 'kubewarden-defaults' ] && retry "kubectl rollout status -n kubewarden deployment/policy-server-default"
     return 0
 }
 
@@ -60,6 +60,10 @@ function retry() {
     local tries=${2:-10}
     local delay=${3:-30}
     local i
+
+    # Github runner is shared - we must use context for cluster commands
+    [[ "$cmd" =~ ^(kubectl|helm) ]] && cmd="${cmd/ / --context $CLUSTER_CONTEXT }"
+
     for ((i=1; i<=tries; i++)); do
         timeout 25 bash -c "$cmd" && break || echo "RETRY #$i: $cmd"
         [ $i -ne $tries ] && sleep $delay || { echo "Godot: $cmd"; false; }


### PR DESCRIPTION
We use single machine with 4 runners. Each runner can create k3d cluster.
If we run multiple tests at the same time then default context can switch during test run.

`retry` function parameter is executed in `bash -c`, so it won't use test context by default. This PR fixes it.
It replaces space after kubectl or helm command with space + context:

`kubectl [space] ...` -> `kubectl --context $CONTEXT [space] ...`.
