### PR TITLE
fix: add controller prometheus target

### DIFF
--- a/resources/opentelemetry-prometheus-values.yaml
+++ b/resources/opentelemetry-prometheus-values.yaml
@@ -10,3 +10,13 @@ prometheus:
       endpoints:
         - port: metrics
           interval: 10s
+    - name: kubewarden-controller
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: kubewarden-controller
+      namespaceSelector:
+        matchNames:
+          - kubewarden
+      endpoints:
+        - port: metrics
+          interval: 10s


### PR DESCRIPTION
## Description

Adds `kubewarden-controller` target to the prometheus targets.
