### PR TITLE
refactor: Use namespaced policy in basic-end-to-end-tests

### DIFF
--- a/resources/psp-user-group-policy.yaml
+++ b/resources/psp-user-group-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: policies.kubewarden.io/v1alpha2
+apiVersion: policies.kubewarden.io/v1
 kind: AdmissionPolicy
 metadata:
   name: psp-user-group

--- a/resources/psp-user-group-policy.yaml
+++ b/resources/psp-user-group-policy.yaml
@@ -1,7 +1,8 @@
 apiVersion: policies.kubewarden.io/v1alpha2
-kind: ClusterAdmissionPolicy
+kind: AdmissionPolicy
 metadata:
   name: psp-user-group
+  namespace: default
 spec:
   policyServer: default
   module: registry://ghcr.io/kubewarden/tests/user-group-psp:v0.4.7
@@ -13,12 +14,12 @@ spec:
           - kubewarden
           - kube-system
   rules:
-  - apiGroups: [""]
-    apiVersions: ["v1"]
-    resources: ["pods"]
-    operations:
-    - CREATE
-    - UPDATE
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["pods"]
+      operations:
+        - CREATE
+        - UPDATE
   mutating: true
   settings:
     run_as_user:
@@ -32,4 +33,3 @@ spec:
       rule: "RunAsAny"
     supplemental_groups:
       rule: "RunAsAny"
-

--- a/tests/basic-end-to-end-tests.bats
+++ b/tests/basic-end-to-end-tests.bats
@@ -41,8 +41,8 @@ teardown_file() {
 	kubectl label pod nginx-privileged x=y
 }
 
-@test "[Basic end-to-end tests] Apply mutating psp-user-group ClusterAdmissionPolicy" {
-	apply_cluster_admission_policy $RESOURCES_DIR/psp-user-group-policy.yaml
+@test "[Basic end-to-end tests] Apply mutating psp-user-group AdmissionPolicy" {
+	apply_admission_policy $RESOURCES_DIR/psp-user-group-policy.yaml
 
 	# Policy should mutate pods
 	kubectl run pause-user-group --image registry.k8s.io/pause


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Expand coverage of basic-end-to-end-tests.bats by refactoring one testcase to be a namesapced AdmissionPolicy.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Run basic-end-to-end-tests.bats locally.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
