### PR TITLE
fix: audit scanner reports tests.

### DIFF
--- a/tests/opentelemetry-tests.bats
+++ b/tests/opentelemetry-tests.bats
@@ -72,8 +72,6 @@ setup() {
     assert_output -p "testing created"
     kubectl wait --for=condition="Complete" job testing --namespace $NAMESPACE
 
-    kubectl get clusterpolicyreports polr-clusterwide
-    kubectl get policyreports polr-ns-default
     retry 'test $(get_metrics policy-server-default | grep protect | grep -oE "policy_name=\"[^\"]+" | sort -u | wc -l) -eq 2'
 }
 


### PR DESCRIPTION
## Description

Updates the tests making use of the audit scanner reports. The latest the audit scanner creates report for all audited resources. Hence, there is no single report for each namespace and cluster-wide resources. This commit fixes the tests by changing how the reports are verified.




Fix #96 
