### PR TITLE
Open telemetry chart requires image repo

### DIFF
--- a/tests/opentelemetry-tests.bats
+++ b/tests/opentelemetry-tests.bats
@@ -13,6 +13,7 @@ setup() {
     # OpemTelementry
     helm repo add --force-update open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
     helm upgrade -i --wait my-opentelemetry-operator open-telemetry/opentelemetry-operator \
+        --set "manager.collectorImage.repository=otel/opentelemetry-collector-contrib" \
         -n open-telemetry --create-namespace
 
     # Prometheus


### PR DESCRIPTION
## Description

Latest [open-telemetry chart](https://github.com/open-telemetry/opentelemetry-helm-charts/releases/tag/opentelemetry-operator-0.56.0) requires collector image be set. Change is described in [their documentation](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/UPGRADING.md#0553-to-0560).

We have 2 options. I tried both and only `collector-contrib` works with our current setup.
 - `otel/opentelemetry-collector-k8s`
 - `otel/opentelemetry-collector-contrib`

Using `otel/opentelemetry-collector-k8s` pruduces this error on opentelemetry-operator pod:
```json
{
"level":"error",
"ts":"2024-04-29T07:04:02Z",
"msg":"failed to select an OpenTelemetry Collector instance for this pod's sidecar",
"namespace":"kubewarden",
"name":"",
"error":"no OpenTelemetry Collector instances available",
"stacktrace":"github.com/open-telemetry/opentelemetry-operator/pkg/sidecar.(*sidecarPodMutator).Mutate\n\t/home/runner/work/opentelemetry-operator/opentelemetry-operator/pkg/sidecar/podmutator.go:85\ngithub.com/open-telemetry/opentelemetry-operator/internal/webhook/podmutation.(*podMutationWebhook).Handle\n\t/home/runner/work/opentelemetry-operator/opentelemetry-operator/internal/webhook/podmutation/webhookhandler.go:93\nsigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/webhook/admission/webhook.go:169\nsigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).ServeHTTP\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.2/pkg/webhook/admission/http.go:119\nsigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics.InstrumentedHook.InstrumentHandlerInFlight.func1\n\t/home/runner/go/pkg/mod/github.com/prometheus/client_golang@v1.19.0/prometheus/promhttp/instrument_server.go:60\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.21.9/x64/src/net/http/server.go:2136\ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1\n\t/home/runner/go/pkg/mod/github.com/prometheus/client_golang@v1.19.0/prometheus/promhttp/instrument_server.go:147\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.21.9/x64/src/net/http/server.go:2136\ngithub.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2\n\t/home/runner/go/pkg/mod/github.com/prometheus/client_golang@v1.19.0/prometheus/promhttp/instrument_server.go:109\nnet/http.HandlerFunc.ServeHTTP\n\t/opt/hostedtoolcache/go/1.21.9/x64/src/net/http/server.go:2136\nnet/http.(*ServeMux).ServeHTTP\n\t/opt/hostedtoolcache/go/1.21.9/x64/src/net/http/server.go:2514\nnet/http.serverHandler.ServeHTTP\n\t/opt/hostedtoolcache/go/1.21.9/x64/src/net/http/server.go:2938\nnet/http.(*conn).serve\n\t/opt/hostedtoolcache/go/1.21.9/x64/src/net/http/server.go:2009"
}
```

