### PR TITLE
Fix audit scanner test

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -153,6 +153,7 @@ function wait_for_cluster_admission_policy {
 }
 
 function wait_for_default_policy_server_rollout {
+    sleep 2 # removing policy does not trigger immediate rollout
 	revision=$(kubectl -n $NAMESPACE get "deployment/policy-server-default" -o json | jq -r '.metadata.annotations."deployment.kubernetes.io/revision"')
 	wait_rollout -n $NAMESPACE --revision $revision "deployment/policy-server-default"
 }


### PR DESCRIPTION
Current test is failing because of couple test bugs:
https://github.com/kubewarden/kubewarden-controller/actions/runs/9200131811/job/25315596449


- `empty` does not check that keys are not present, this code passes only because of missing `-e`
```
jq '[.results[] | select(.policy == "clusterwide-psa-label-enforcer-policy")] | empty'
```
- kubectl returns no results so jq always fail because of no input (if tested cluster is clean)
```
retry "kubectl get --ignore-not-found policyreport -A -o json | jq -e '.items[] | empty'"
```
- created helper methods to clean up checks
- rewrote jq expressions