### PR TITLE
Fix wait_for_default_policy_server_rollout

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -153,7 +153,6 @@ function wait_for_cluster_admission_policy {
 }
 
 function wait_for_default_policy_server_rollout {
-    sleep 2 # removing policy does not trigger immediate rollout
-	revision=$(kubectl -n $NAMESPACE get "deployment/policy-server-default" -o json | jq -r '.metadata.annotations."deployment.kubernetes.io/revision"')
+	revision=$(kubectl -n $NAMESPACE get "deployment/policy-server-default" -o json | jq -er '.metadata.annotations."deployment.kubernetes.io/revision"')
 	wait_rollout -n $NAMESPACE --revision $revision "deployment/policy-server-default"
 }

--- a/tests/opentelemetry-tests.bats
+++ b/tests/opentelemetry-tests.bats
@@ -66,7 +66,7 @@ setup() {
     kubectl wait --for=condition=Ready pod nginx-privileged
 
     # Deploy some policy
-    apply_cluster_admission_policy $RESOURCES_DIR/privileged-pod-policy.yaml
+    kubectl apply -f $RESOURCES_DIR/privileged-pod-policy.yaml
     apply_cluster_admission_policy $RESOURCES_DIR/namespace-label-propagator-policy.yaml
 
     run kubectl create job  --from=cronjob/audit-scanner testing  --namespace $NAMESPACE


### PR DESCRIPTION
## Description

Follow-up PR for https://github.com/kubewarden/kubewarden-controller/issues/745

- remove unnecessary sleep
- add `-e` jq parameter to fail on error / null
- wait only for last applied policy
