### PR TITLE
fix: do not use revision to wait for rollout.

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -153,6 +153,5 @@ function wait_for_cluster_admission_policy {
 }
 
 function wait_for_default_policy_server_rollout {
-	revision=$(kubectl -n $NAMESPACE get "deployment/policy-server-default" -o json | jq -er '.metadata.annotations."deployment.kubernetes.io/revision"')
-	wait_rollout -n $NAMESPACE --revision $revision "deployment/policy-server-default"
+	wait_rollout -n $NAMESPACE  "deployment/policy-server-default"
 }


### PR DESCRIPTION
## Description

Recently our tests start to fail because the deployment take some time to get the revision annotation to be updated. Update test to wait for the latest rollout in progress. Instead of wait for specific revision.

Fix https://github.com/kubewarden/kubewarden-controller/issues/745
