### PR TITLE
Reuse helm values in reconfiguration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ tests: $(filter-out upgrade.bats audit-scanner-installation.bats, $(TESTS))
 .PHONY: cluster install reinstall clean
 
 cluster:
-	k3d cluster create $(CLUSTER_NAME) -s 1 -a 1 --wait --timeout $(TIMEOUT) -v /dev/mapper:/dev/mapper --image rancher/k3s:v1.24.12-k3s1
+	k3d cluster create $(CLUSTER_NAME) -s 1 -a 1 --wait --timeout $(TIMEOUT) -v /dev/mapper:/dev/mapper --image rancher/k3s:v1.27.12-k3s1
 	$(kube) wait --for=condition=Ready nodes --all
 
 install:

--- a/tests/reconfiguration-tests.bats
+++ b/tests/reconfiguration-tests.bats
@@ -16,12 +16,12 @@ teardown_file() {
 }
 
 @test "[Reconfiguration tests] Reconfigure Kubewarden stack" {
-	helm_up kubewarden-controller --values=$RESOURCES_DIR/reconfiguration-values.yaml
+	helm_up kubewarden-controller --values=$RESOURCES_DIR/reconfiguration-values.yaml --reuse-values
 	wait_for_cluster_admission_policy PolicyActive
 }
 
 @test "[Reconfiguration tests] Apply psp-user-group policy" {
-	apply_cluster_admission_policy $RESOURCES_DIR/psp-user-group-policy.yaml
+	apply_admission_policy $RESOURCES_DIR/psp-user-group-policy.yaml
 }
 
 @test "[Reconfiguration tests] Test that pod-privileged policy works" {


### PR DESCRIPTION
Reconfiguration test on nightly job downgrades controller from latest to 1.13.0. This should fix the issue.

From debug with @jvanz :
We have two finalizers: kubewarden (old one) and [kubewarden.io/finalizer](http://kubewarden.io/finalizer) (the latest). In the test we are creating the cluster with the version v1.13.0 which uses the kubewarden finalizer. Then, we change the controller version to latest which will add the [kubewarden.io/finalizer](http://kubewarden.io/finalizer) finalizer. However, during the reconfiguration tests we downgrade back to the v1.13.0 , right? Therefore, we ended in a situation where the controller does not "know" the new finalizer, because is the "old" version. Thus, the finalizer ([kubewarden.io/finalizer](http://kubewarden.io/finalizer) ) is not removed and the resource is not deleted.
