### PR TITLE
fix: remove Otel resources before running other Otel test.

### DIFF
--- a/tests/opentelemetry-remote-collector-tests.bats
+++ b/tests/opentelemetry-remote-collector-tests.bats
@@ -14,6 +14,9 @@ teardown_file() {
     kubectl delete admissionpolicies,clusteradmissionpolicies --all -A
     kubectl delete pod nginx-privileged nginx-unprivileged --ignore-not-found
 
+    kubectl delete --wait --ignore-not-found -f $RESOURCES_DIR/opentelemetry-jaeger.yaml
+    kubectl delete --wait --ignore-not-found --namespace $NAMESPACE -f $RESOURCES_DIR/otel-collector-deployment.yaml
+
     # Remove installed apps
     helm uninstall --wait -n jaeger jaeger-operator
     helm uninstall --wait -n prometheus prometheus


### PR DESCRIPTION
## Description

Depending the order of execution of the OpenTelemetry tests they can fail because one test is trying to install/upgrade a resource which are in terminating state. It's possible to see error messages like:

"create not allowed while custom resource definition is terminating"

To workaround this problem, this commit updates the test that verify the communication with remote Otel collector to removes the resources created during the test as well.


