### PR TITLE
Hardcode PolicyReports CRD source on audit-scanner test

### DIFF
--- a/tests/audit-scanner-installation.bats
+++ b/tests/audit-scanner-installation.bats
@@ -5,7 +5,9 @@ setup() {
     wait_pods -n kube-system
 }
 
-CRD_BASE=https://github.com/kubernetes-sigs/wg-policy-prototypes/raw/master/policy-report/crd/v1alpha2/
+# Hardcode PolicyReports to v1alpha2 from clusterpolicyreports.wgpolicyk8s.io and not clusterpolicyreports.x-k8s.io
+# We will need to migrate later in time.
+CRD_BASE=https://github.com/kubernetes-sigs/wg-policy-prototypes/tree/af8c5984c89aa95d8a6719d3994e71ecc31ce6c3/policy-report/crd/v1alpha2/
 
 function kubewarden_uninstall {
     helmer uninstall defaults --ignore-not-found


### PR DESCRIPTION


## Description

This fixes the audit-scanner installation test failure (see [here](https://github.com/kubewarden/helm-charts/actions/runs/12739446482/job/35503149835)).

The GitHub source for the PolicyReports CRD has changed (see [here](https://togithub.com/kubernetes-sigs/wg-policy-prototypes/pull/135)). Since there's no formal release yet, hardcode the source in this specific test.

PolicyReports' CRD source is changing since they will move from `clusterpolicyreports.wgpolicyk8s.io` to `clusterpolicyreports.x-k8s.io`, and from ` v1alpha2` to `v1beta2`. Since this bump needs to be performed in lockstep with policy-reporter and our PolicyReports CRDs we ship in our Helm charts, hardcode it for now.

<!-- Please provide the link to the GitHub issue you are addressing -->

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
Untested, will use CI to run E2E tests.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
