### PR TITLE
Authenticate k3d registry to dockerhub

### DIFF
--- a/scripts/cluster_k3d.sh
+++ b/scripts/cluster_k3d.sh
@@ -23,6 +23,7 @@ if [ "${1:-}" == 'create' ]; then
         --image rancher/k3s:$K3S \
         -s $MASTER_COUNT -a $WORKER_COUNT \
         --registry-create k3d-$CLUSTER_NAME-registry \
+        --registry-config <(echo "${K3D_REGISTRY_CONFIG:-}") \
         -v /dev/mapper:/dev/mapper
     wait_pods -n kube-system
 fi


### PR DESCRIPTION
## Description

E2E test failed on docker rate limit: https://github.com/kubewarden/helm-charts/actions/runs/13378490082/job/37362615670#step:7:23

This PR applies dockerhub authentication that we created for this purpose.