### PR TITLE
Lock opentelemetry-operator to 0.80.2

### DIFF
--- a/scripts/helmer.sh
+++ b/scripts/helmer.sh
@@ -144,7 +144,7 @@ do_upgrade() {
 
         if [ "$chart" = 'controller' ]; then
             [[ "${vMap[$chart]}" == 4.1* ]] && continue # Url renamed to Module in PS ConfigMap
-            [[ "${vMap[$chart]}" == 4.2* ]] && continue # Probe port change from https to http
+            [[ "${vMap[$chart]}" == 5.0* ]] && continue # Probe port change from https to http
             sleep 20 # Wait for reconciliation
             wait_rollout -n $NAMESPACE deployment/policy-server-default
         fi

--- a/tests/opentelemetry-tests.bats
+++ b/tests/opentelemetry-tests.bats
@@ -50,7 +50,7 @@ export -f get_metrics # required by retry command
     helm repo add --force-update open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
     helm upgrade -i --wait my-opentelemetry-operator open-telemetry/opentelemetry-operator \
         --set "manager.collectorImage.repository=otel/opentelemetry-collector-contrib" \
-        -n open-telemetry --create-namespace
+        -n open-telemetry --create-namespace --version 0.80.2 # Lock version because of https://github.com/kubewarden/kubewarden-controller/issues/1026
 
     # Prometheus
     helm repo add --force-update prometheus-community https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
Based on this issue https://github.com/kubewarden/kubewarden-controller/issues/1026

Fixes e2e tests currently failing on OTEL.

Also fixes version numbers from 1.22 release