### PR TITLE
Add support for k3d mtls cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 resources/resources_*/
+resources/mtls/domain.*
+resources/mtls/rootCA.*
 charts

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ CLUSTER_CONTEXT ?= $(shell kubectl config current-context)
 # Optional arguments for scripts
 
 # cluster_k3d.sh:
+#   MTLS=1
 #   K3S=[1.30] - short|long version
 #   CLUSTER_NAME=[k3d-default]
 

--- a/helpers/helpers.sh
+++ b/helpers/helpers.sh
@@ -83,8 +83,8 @@ function wait_policies {
     # Policy groups were added in Kubewarden >= v1.17.0
     kw_version ">=1.17" && resources+=",admissionpolicygroups,clusteradmissionpolicygroups"
 
-    for chart in ${1:-PolicyActive PolicyUniquelyReachable}; do
-        wait_for --for=condition="$1" "$resources" --all -A
+    for state in ${1:-PolicyActive PolicyUniquelyReachable}; do
+        wait_for --for=condition="$state" "$resources" --all -A
     done
 }
 

--- a/resources/mtls/admission.yaml
+++ b/resources/mtls/admission.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+- name: ValidatingAdmissionWebhook
+  configuration:
+    apiVersion: apiserver.config.k8s.io/v1
+    kind: WebhookAdmissionConfiguration
+    kubeConfigFile: "/etc/mtls/kubeconfig"
+- name: MutatingAdmissionWebhook
+  configuration:
+    apiVersion: apiserver.config.k8s.io/v1
+    kind: WebhookAdmissionConfiguration
+    kubeConfigFile: "/etc/mtls/kubeconfig"

--- a/resources/mtls/kubeconfig
+++ b/resources/mtls/kubeconfig
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Config
+users:
+# Target all services in kubewarden namespace
+- name: '*.kubewarden.svc'
+  user:
+    client-certificate: /etc/mtls/domain.crt
+    client-key: /etc/mtls/domain.key

--- a/tests/mutual-tls.bats
+++ b/tests/mutual-tls.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+
+setup() {
+    load ../helpers/helpers.sh
+    wait_pods
+}
+
+setup_file() {
+    load ../helpers/helpers.sh
+    kubectl get cm -n $NAMESPACE mtlscm &>/dev/null || kubectl create cm -n $NAMESPACE mtlscm --from-file="client-ca.crt=$RESOURCES_DIR/mtls/rootCA.crt"
+}
+
+teardown_file() {
+    load ../helpers/helpers.sh
+    helmer reset kubewarden-defaults
+    helmer reset kubewarden-controller
+}
+
+# Skip tests if MTLS is disabled
+[[ "${MTLS:-}" =~ ^(false|0)?$ ]] && skip "Mutual TLS is disabled"
+
+@test "[Mutual TLS] Enable mTLS" {
+    helmer set kubewarden-controller --set mTLS.enable=true --set mTLS.configMapName=mtlscm
+
+    kubectl get nodes -l node-role.kubernetes.io/control-plane -o yaml | grep -F "admission-control-config-file"
+    kubectl logs -n kubewarden -l kubewarden/policy-server=default | grep -E "certs: Loaded client CA certificates client_ca_certs_added=[1-9]"
+
+    # Run more checks? What to check for?
+    # How to check I can't talk to webhook now?
+    # helmer set kubewarden-defaults --set recommendedPolicies.enabled=True
+}
+
+@test "[Mutual TLS] Disable mTLS" {
+    helmer set kubewarden-controller --set mTLS.enable=false
+
+    ! kubectl get nodes -l node-role.kubernetes.io/control-plane -o yaml | grep -F "admission-control-config-file"
+    ! kubectl logs -n kubewarden -l kubewarden/policy-server=default | grep -E "certs: Loaded client CA certificates client_ca_certs_added=[1-9]"
+}


### PR DESCRIPTION
`make clean cluster install CHARTS_LOCATION=./charts LATEST=1 MTLS=1`

Initial draft of mtls test:
 - so far it creates k3d cluster with mtls support
 - deploys kubewarden with mtls enabled
 - uses local charts from https://github.com/kubewarden/helm-charts/pull/638

There are 2 options to run MTLS test:
```bash
# Create mTLS enabled cluster (requirement)
make cluster MTLS=1

# Option 1 - install kubewarden with mTLS enabled, all tests run in mTLS env
make install MTLS=1 # enable mTLS during kubewarden installation
make tests MTLS=1   # enable mutual-tls.bats test

# Option 2 - install kubewarden without mTLS, all tests run as before
make install      # install kubewarden without mTLS
make tests MTLS=1 # enable mTLS only during mutual-tls.bats test
```