### PR TITLE
Add e2e tests for policy group

### DIFF
--- a/helpers/helpers.sh
+++ b/helpers/helpers.sh
@@ -40,6 +40,13 @@ function kubefail_privileged {
     assert_output --regexp '^Error.*: admission webhook.*denied the request.*container is not allowed$'
 }
 
+# Run kubectl action which should fail on pod using privileged escalation or shared pid namespace without the mandatory annotation
+function kubefail_policy_group {
+    run kubectl "$@"
+    assert_failure 1
+    assert_output --regexp '^Error.*: admission webhook.*denied the request: the pod is using privileged escalation or shared pid namespace and has not the mandatory annotation$'
+}
+
 # Prepend policies with RESOURCE dir if file doesn't contain '/'
 policypath() { [[ "$1" == */* ]] && echo "$1" || echo "$RESOURCES_DIR/policies/$1"; }
 

--- a/resources/policies/policy-group-escalation-shared-pid.yaml
+++ b/resources/policies/policy-group-escalation-shared-pid.yaml
@@ -1,0 +1,26 @@
+apiVersion: policies.kubewarden.io/v1
+kind: ClusterAdmissionPolicyGroup
+metadata:
+  name: policy-group
+spec:
+  rules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      resources: ["pods"]
+      operations:
+        - CREATE
+        - UPDATE
+  policies:
+    mandatory_pod_annotations:
+      module: ghcr.io/kubewarden/policies/safe-annotations
+      settings:
+        mandatory_annotations:
+          - super_pod
+    denied_shared_process_namespace:
+      module: ghcr.io/kubewarden/policies/share-pid-namespace-policy
+    denied_privilege_escalation:
+      module: ghcr.io/kubewarden/policies/allow-privilege-escalation-psp
+      settings:
+        default_allow_privilege_escalation: false
+  expression: "mandatory_pod_annotations() || (denied_privilege_escalation() && denied_shared_process_namespace())"
+  message: "the pod is using privileged escalation or shared pid namespace and has not the mandatory annotation"

--- a/tests/basic-end-to-end-tests.bats
+++ b/tests/basic-end-to-end-tests.bats
@@ -8,7 +8,7 @@ setup() {
 teardown_file() {
     load ../helpers/helpers.sh
     kubectl delete pods --all
-    kubectl delete admissionpolicies,clusteradmissionpolicies --all -A
+    kubectl delete ap,cap,capg --all -A
 }
 
 # Create pod-privileged policy to block CREATE & UPDATE of privileged pods
@@ -24,7 +24,7 @@ teardown_file() {
 }
 
 # Update pod-privileged policy to block only UPDATE of privileged pods
-@test  "[Basic end-to-end tests] Patch policy to block only UPDATE operation" {
+@test "[Basic end-to-end tests] Patch policy to block only UPDATE operation" {
     yq '.spec.rules[0].operations = ["UPDATE"]' $RESOURCES_DIR/policies/privileged-pod-policy.yaml | kubectl apply -f -
 
     # I can create privileged pods now
@@ -61,4 +61,30 @@ teardown_file() {
     wait_policyserver e2e-tests
 
     kubectl delete -f $RESOURCES_DIR/policy-server.yaml
+}
+
+@test "[Basic end-to-end tests] Apply policy group to block privileged escalation and shared pid namespace pods" {
+    apply_policy policy-group-escalation-shared-pid.yaml
+
+    # I can not create pod using privileged escalation only
+    kubefail_policy_group run nginx-denied-privi-escalation --image=nginx:alpine \
+        --overrides='{"spec":{"containers":[{"name":"nginx-denied-privi-escalation","image":"nginx:alpine","securityContext":{"allowPrivilegeEscalation":true}}]}}'
+
+    # I can not create pod using shared pid namespace only
+    kubefail_policy_group run nginx-denied-shared-pid --image=nginx:alpine \
+        --overrides='{"spec":{"shareProcessNamespace":true}}'
+
+    # I can create pod using shared pid namespace with the mandatory annotation
+    kubectl run nginx-shared-pid --image=nginx:alpine --annotations="super_pod=true" \
+        --overrides='{"spec":{"shareProcessNamespace":true}}'
+
+    # I can create pod using privileged escalation with the mandatory annotation
+    kubectl run nginx-privi-escalation --image=nginx:alpine --annotations="super_pod=true" \
+        --overrides='{"spec":{"containers":[{"name":"nginx-privi-escalation","image":"nginx:alpine","securityContext":{"allowPrivilegeEscalation":true}}]}}'
+
+    # I can create pod using privileged escalation and shared pid namespace with the mandatory annotation
+    kubectl run nginx-privi-escalation-shared-pid --image=nginx:alpine --annotations="super_pod=true" \
+        --overrides='{"spec":{"shareProcessNamespace":true,"containers":[{"name":"nginx-privi-escalation-shared-pid","image":"nginx:alpine","securityContext":{"allowPrivilegeEscalation":true}}]}}'
+    
+    delete_policy policy-group-escalation-shared-pid.yaml
 }


### PR DESCRIPTION
## Description

Add e2e test for policy group, it will make sure we can not create a pod with privileged escalation or shared pid namespace without using the mandatory annotation `super_pod`.

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #143 

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

```shell
make basic-end-to-end-tests.bats
```

![image](https://github.com/user-attachments/assets/b70938d0-c918-4051-ab68-038d4a1f2d93)


## Additional Information

### Potential improvement

Delete the policy group and test to run a pod with privileged escalation?
