### PR TITLE
Rework kuberun function and fix OTEL test

### DIFF
--- a/helpers/helpers.sh
+++ b/helpers/helpers.sh
@@ -25,14 +25,6 @@ trigger_audit_scan() {
     kubectl delete job $jobname --namespace $NAMESPACE
 }
 
-# Run & delete pod with optional parameters. Check exit code.
-# kuberun [-0|-1|-N|!] "--privileged"
-function kuberun {
-    local status=-0
-    [[ $1 =~ ^([!]|-[0-9]+)$ ]] && status="$1" && shift
-    run "$status" kubectl run "pod-$(date +%s)" --image=busybox --restart=Never --rm -it --command "$@" -- true
-}
-
 # Run kubectl action which should fail on pod privileged policy
 function kubefail_privileged {
     run kubectl "$@"

--- a/tests/mutual-tls.bats
+++ b/tests/mutual-tls.bats
@@ -61,7 +61,7 @@ function check_service_mtls {
 
     # Check protected policy still blocks requests
     apply_policy safe-labels-pods-policy.yaml
-    kuberun ! -l cost-center=lbl
+    run ! kuberun -l cost-center=lbl
 }
 
 @test "[Mutual TLS] Disable mTLS" {

--- a/tests/opentelemetry-tests.bats
+++ b/tests/opentelemetry-tests.bats
@@ -63,6 +63,8 @@ export -f get_metrics # required by retry command
     helm upgrade -i --wait jaeger-operator jaegertracing/jaeger-operator \
         -n jaeger --create-namespace \
         --set rbac.clusterRole=true
+    # Wait for service: Internal error occurred: failed calling webhook "mjaeger.kb.io": failed to call webhook
+    retry "kuberun wget -O- https://jaeger-operator-webhook-service.jaeger.svc/mutate-jaegertracing-io-v1-jaeger" 2 10
 
     kubectl apply -f $RESOURCES_DIR/opentelemetry-jaeger.yaml
     wait_pods -n jaeger


### PR DESCRIPTION
- Added wait for jaeger webhook because of occasional `502 Bad Gateway` when accessing it too early:
https://github.com/kubewarden/helm-charts/actions/runs/13909762541/job/38921184984#step:9:226

- Updated kuberun helper. Now it does not require bats and can run inside of retry.
It can be used to check if pod can start and to run commands inside pod.
It creates pod (busybox by default), runs a command (-- true if not specified) and deletes pod afterwards.

```
# Check we can't run privileged pods
run ! kuberun --privileged
assert_output "error ..."

# Check we can run privileged pods
kuberun --privileged

# Check webhook
kuberun wget -O- jaeger-webhook.jaeger.svc
```
