### PR TITLE
Test changes for arm support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,9 @@ updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
   open-pull-requests-limit: 10
+- package-ecosystem: "gitsubmodule"
+  directory: "/"
+  schedule:
+    interval: "weekly"

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,20 @@ CLUSTER_CONTEXT ?= $(shell kubectl config current-context)
 #   CRDS_ARGS, DEFAULTS_ARGS, CONTROLLER_ARGS
 
 # ==================================================================================================
+# Github boolean "false" is interpreted as a string (true) by bash
+# Github falsy values (false, 0, -0, "", '', null) are coerced to false
+
+# Boolean variables from github workflow
+VARIABLES = MTLS LATEST UPGRADE
+
+define is_falsy
+$(filter false 0 -0 "" '' null,$($(1)))
+endef
+
+# Process each variable - if it has a falsy value, override it to be empty
+$(foreach var,$(VARIABLES),$(if $(call is_falsy,$(var)),$(eval override $(var)=),))
+
+# ==================================================================================================
 # Targets
 
 .PHONY: clean cluster install upgrade uninstall tests all

--- a/helpers/kubelib.sh
+++ b/helpers/kubelib.sh
@@ -58,7 +58,8 @@ function wait_nodes() {
     done
 }
 
-function wait_for    () { kubectl wait --timeout=5m "$@"; }
+# Wait for Ready condition by default, could be overridden with --for=condition=...
+function wait_for    () { kubectl wait --timeout=5m --for=condition=Ready "$@"; }
 # Wait for terminating pods after rollout
 function wait_rollout() { kubectl rollout status --timeout=5m "$@"; wait_pods; }
 

--- a/helpers/kubelib.sh
+++ b/helpers/kubelib.sh
@@ -10,6 +10,10 @@ info () { log 0  "  ${*}"; }
 warn () { log 33 "  ${*}"; }
 error() { log 31 "  ${*}"; }
 
+# Check github truthy | falsy variables
+gh_true() { ! is_false "$1"; }
+gh_false() { [[ "${!1:-}" =~ ^(false|0|-0|null)$ ]]; }
+
 # ==================================================================================================
 # Kubernetes helpers
 

--- a/scripts/helmer.sh
+++ b/scripts/helmer.sh
@@ -85,7 +85,7 @@ make_version_map() {
                 {
                     ($v): remap(map(select(.app_version == $v))),
                     next: remap($latest),
-                    prev: remap(map(select(.app_version != $latest[0].app_version and (.app_version | contains("-rc") | not)))),
+                    prev: remap(map(select(.app_version != $latest[0].app_version and (.app_version | test("-rc|-beta|-alpha") | not)))),
                 }' > "$tempfile"
     fi
 

--- a/tests/audit-scanner.bats
+++ b/tests/audit-scanner.bats
@@ -60,11 +60,11 @@ check_report_result() {
 
     # Launch unprivileged pod
     kubectl run nginx-unprivileged --image=nginx:alpine
-    kubectl wait --for=condition=Ready pod nginx-unprivileged
+    wait_for pod nginx-unprivileged
 
     # Launch privileged pod
     kubectl run nginx-privileged --image=registry.k8s.io/pause --privileged
-    kubectl wait --for=condition=Ready pod nginx-privileged
+    wait_for pod nginx-privileged
 
     # Create a namespace to trigger a fail evaluation in the audit scanner
     kubectl create ns testing-audit-scanner

--- a/tests/audit-scanner.bats
+++ b/tests/audit-scanner.bats
@@ -63,7 +63,7 @@ check_report_result() {
     wait_for pod nginx-unprivileged
 
     # Launch privileged pod
-    kubectl run nginx-privileged --image=registry.k8s.io/pause --privileged
+    kubectl run nginx-privileged --image=rancher/pause:3.2 --privileged
     wait_for pod nginx-privileged
 
     # Create a namespace to trigger a fail evaluation in the audit scanner

--- a/tests/basic-end-to-end-tests.bats
+++ b/tests/basic-end-to-end-tests.bats
@@ -17,7 +17,7 @@ teardown_file() {
 
     # Launch unprivileged pod
     kubectl run nginx-unprivileged --image=nginx:alpine
-    kubectl wait --for=condition=Ready pod nginx-unprivileged
+    wait_for pod nginx-unprivileged
 
     # Launch privileged pod (should fail)
     kubefail_privileged run pod-privileged --image=registry.k8s.io/pause --privileged
@@ -45,8 +45,10 @@ teardown_file() {
     apply_policy psp-user-group-policy.yaml
 
     # Policy should mutate pods
-    kubectl run pause-user-group --image registry.k8s.io/pause
-    kubectl wait --for=condition=Ready pod pause-user-group
+    kubectl run pause-user-group --image rancher/pause:3.6
+    sleep 30
+    kubectl describe pod pause-user-group
+    wait_for pod pause-user-group
     kubectl get pods pause-user-group -o json | jq -e ".spec.containers[].securityContext.runAsUser==1000"
 
     delete_policy psp-user-group-policy.yaml

--- a/tests/basic-end-to-end-tests.bats
+++ b/tests/basic-end-to-end-tests.bats
@@ -20,7 +20,7 @@ teardown_file() {
     wait_for pod nginx-unprivileged
 
     # Launch privileged pod (should fail)
-    kubefail_privileged run pod-privileged --image=registry.k8s.io/pause --privileged
+    kubefail_privileged run pod-privileged --image=rancher/pause:3.2 --privileged
 }
 
 # Update pod-privileged policy to block only UPDATE of privileged pods
@@ -45,9 +45,7 @@ teardown_file() {
     apply_policy psp-user-group-policy.yaml
 
     # Policy should mutate pods
-    kubectl run pause-user-group --image rancher/pause:3.6
-    sleep 30
-    kubectl describe pod pause-user-group
+    kubectl run pause-user-group --image rancher/pause:3.2
     wait_for pod pause-user-group
     kubectl get pods pause-user-group -o json | jq -e ".spec.containers[].securityContext.runAsUser==1000"
 

--- a/tests/context-aware-requests-tests.bats
+++ b/tests/context-aware-requests-tests.bats
@@ -20,7 +20,7 @@ teardown_file() {
     kubectl annotate namespaces ctx-test propagate.hello=world
 
     kubectl run --namespace ctx-test pause-user-group --image registry.k8s.io/pause
-    kubectl wait --for=condition=Ready pod --namespace ctx-test pause-user-group
+    wait_for pod --namespace ctx-test pause-user-group
     kubectl get pod --namespace ctx-test pause-user-group -o json | jq -e '.metadata.labels["hello"]=="world"'
     kubectl delete namespace ctx-test
 

--- a/tests/context-aware-requests-tests.bats
+++ b/tests/context-aware-requests-tests.bats
@@ -19,7 +19,7 @@ teardown_file() {
     kubectl create ns ctx-test
     kubectl annotate namespaces ctx-test propagate.hello=world
 
-    kubectl run --namespace ctx-test pause-user-group --image registry.k8s.io/pause
+    kubectl run --namespace ctx-test pause-user-group --image rancher/pause:3.2
     wait_for pod --namespace ctx-test pause-user-group
     kubectl get pod --namespace ctx-test pause-user-group -o json | jq -e '.metadata.labels["hello"]=="world"'
     kubectl delete namespace ctx-test

--- a/tests/monitor-mode-tests.bats
+++ b/tests/monitor-mode-tests.bats
@@ -28,7 +28,7 @@ teardown_file() {
     apply_policy privileged-pod-policy.yaml
 
     # Launch privileged pod (should fail)
-    kubefail_privileged run pod-privileged --image=registry.k8s.io/pause --privileged
+    kubefail_privileged run pod-privileged --image=rancher/pause:3.2 --privileged
 }
 
 @test "[Monitor mode end-to-end tests] Transition from protect to monitor should be disallowed" {

--- a/tests/mutating-requests-tests.bats
+++ b/tests/mutating-requests-tests.bats
@@ -17,7 +17,7 @@ teardown_file() {
 
     # New pod should be mutated by the policy
     kubectl run pause-user-group --image registry.k8s.io/pause
-    kubectl wait --for=condition=Ready pod pause-user-group
+    wait_for pod pause-user-group
     kubectl get pod pause-user-group -o json | jq -e ".spec.containers[].securityContext.runAsUser==1000"
     kubectl delete pod pause-user-group
 

--- a/tests/mutating-requests-tests.bats
+++ b/tests/mutating-requests-tests.bats
@@ -16,7 +16,7 @@ teardown_file() {
     apply_policy mutate-policy-with-flag-enabled.yaml
 
     # New pod should be mutated by the policy
-    kubectl run pause-user-group --image registry.k8s.io/pause
+    kubectl run pause-user-group --image rancher/pause:3.2
     wait_for pod pause-user-group
     kubectl get pod pause-user-group -o json | jq -e ".spec.containers[].securityContext.runAsUser==1000"
     kubectl delete pod pause-user-group
@@ -28,7 +28,7 @@ teardown_file() {
     apply_policy mutate-policy-with-flag-disabled.yaml
 
     # New pod should be rejected by psp-user-group-policy
-    run kubectl run pause-user-group --image registry.k8s.io/pause
+    run kubectl run pause-user-group --image rancher/pause:3.2
     assert_failure
     assert_output --partial "The policy attempted to mutate the request, but it is currently configured to not allow mutations"
 

--- a/tests/mutual-tls.bats
+++ b/tests/mutual-tls.bats
@@ -37,7 +37,7 @@ function check_service_mtls {
 
     # Set up pod with certificates for curl
     kubectl run curlpod --image=nginx:alpine
-    kubectl wait --for=condition=Ready pod curlpod
+    wait_for pod curlpod
     kubectl cp resources/mtls curlpod:/mtls
 }
 

--- a/tests/namespaced-admission-policy-tests.bats
+++ b/tests/namespaced-admission-policy-tests.bats
@@ -19,12 +19,12 @@ teardown_file() {
 
     # Privileged pod in the kubewarden namespace (should work)
     kubectl run nginx-privileged --image=nginx:alpine --privileged -n $NAMESPACE
-    kubectl wait --for=condition=Ready pod nginx-privileged -n $NAMESPACE
+    wait_for pod nginx-privileged -n $NAMESPACE
     kubectl delete pod nginx-privileged -n $NAMESPACE
 
     # Unprivileged pod in default namespace (should work)
     kubectl run nginx-unprivileged --image=nginx:alpine
-    kubectl wait --for=condition=Ready pod nginx-unprivileged
+    wait_for pod nginx-unprivileged
     kubectl delete pod nginx-unprivileged
 }
 

--- a/tests/opentelemetry-tests.bats
+++ b/tests/opentelemetry-tests.bats
@@ -86,7 +86,7 @@ export -f get_metrics # required by retry command
     kubectl get services -n $NAMESPACE kubewarden-controller-metrics-service -o json | jq -e '[.spec.ports[].name == "metrics"] | any'
 
     # Generate metric data
-    kubectl run pod-privileged --image=registry.k8s.io/pause --privileged
+    kubectl run pod-privileged --image=rancher/pause:3.2 --privileged
     wait_for pod pod-privileged
     kubectl delete --wait pod pod-privileged
 
@@ -101,7 +101,7 @@ export -f get_metrics # required by retry command
     # Launch unprivileged & privileged pods
     kubectl run nginx-unprivileged --image=nginx:alpine
     wait_for pod nginx-unprivileged
-    kubectl run nginx-privileged --image=registry.k8s.io/pause --privileged
+    kubectl run nginx-privileged --image=rancher/pause:3.2 --privileged
     wait_for pod nginx-privileged
 
     # Deploy some policy
@@ -141,7 +141,7 @@ export -f get_metrics # required by retry command
 
 @test "[OpenTelemetry Remote collector] Metrics are sent to remote Otel collector" {
     # Generate metric data
-    kubectl run pod-privileged --image=registry.k8s.io/pause --privileged
+    kubectl run pod-privileged --image=rancher/pause:3.2 --privileged
     wait_for pod pod-privileged
     kubectl delete --wait pod pod-privileged
 

--- a/tests/opentelemetry-tests.bats
+++ b/tests/opentelemetry-tests.bats
@@ -87,7 +87,7 @@ export -f get_metrics # required by retry command
 
     # Generate metric data
     kubectl run pod-privileged --image=registry.k8s.io/pause --privileged
-    kubectl wait --for=condition=Ready pod pod-privileged
+    wait_for pod pod-privileged
     kubectl delete --wait pod pod-privileged
 
     # Policy server & controller metrics should be available
@@ -100,9 +100,9 @@ export -f get_metrics # required by retry command
 
     # Launch unprivileged & privileged pods
     kubectl run nginx-unprivileged --image=nginx:alpine
-    kubectl wait --for=condition=Ready pod nginx-unprivileged
+    wait_for pod nginx-unprivileged
     kubectl run nginx-privileged --image=registry.k8s.io/pause --privileged
-    kubectl wait --for=condition=Ready pod nginx-privileged
+    wait_for pod nginx-privileged
 
     # Deploy some policy
     apply_policy --no-wait privileged-pod-policy.yaml
@@ -142,7 +142,7 @@ export -f get_metrics # required by retry command
 @test "[OpenTelemetry Remote collector] Metrics are sent to remote Otel collector" {
     # Generate metric data
     kubectl run pod-privileged --image=registry.k8s.io/pause --privileged
-    kubectl wait --for=condition=Ready pod pod-privileged
+    wait_for pod pod-privileged
     kubectl delete --wait pod pod-privileged
 
     retry 'test $(get_metrics my-collector-collector | grep "kubewarden_policy_total" | wc -l) -gt 1'

--- a/tests/reconfiguration-tests.bats
+++ b/tests/reconfiguration-tests.bats
@@ -27,7 +27,7 @@ teardown_file() {
 @test "[Reconfiguration tests] Test that pod-privileged policy works" {
     # Launch unprivileged pod
     kubectl run pause-unprivileged --image registry.k8s.io/pause
-    kubectl wait --for=condition=Ready pod pause-unprivileged
+    wait_for pod pause-unprivileged
 
     # Launch privileged pod (should fail)
     kubefail_privileged run pause-privileged --image registry.k8s.io/pause --privileged

--- a/tests/reconfiguration-tests.bats
+++ b/tests/reconfiguration-tests.bats
@@ -26,9 +26,9 @@ teardown_file() {
 
 @test "[Reconfiguration tests] Test that pod-privileged policy works" {
     # Launch unprivileged pod
-    kubectl run pause-unprivileged --image registry.k8s.io/pause
+    kubectl run pause-unprivileged --image rancher/pause:3.2
     wait_for pod pause-unprivileged
 
     # Launch privileged pod (should fail)
-    kubefail_privileged run pause-privileged --image registry.k8s.io/pause --privileged
+    kubefail_privileged run pause-privileged --image rancher/pause:3.2 --privileged
 }


### PR DESCRIPTION
Related issue: https://github.com/kubewarden/kubewarden-end-to-end-tests/issues/37

## Description

- switched to rancher/pause:3.2 image because it supports arm
- use wait_for helper function with extended timeout
- enabled dependabot for git submodules (bats)
- handle boolean values from github workflow in bash
- fix helmer detection of pre-releases (beta,alpha)
