### PR TITLE
fix: mTLS used unsupported skip command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,14 @@ $(TESTFILES):
 	CLUSTER_CONTEXT=$(CLUSTER_CONTEXT) \
 	bats -T --print-output-on-failure $(TESTS_DIR)/$@
 
-# Target all non-destructive tests
-tests: $(filter-out audit-scanner-installation.bats, $(TESTFILES))
+# Filter out audit-scanner-installation because it reinstalls kubewarden
+FILTERED := $(filter-out audit-scanner-installation.bats, $(TESTFILES))
+# Filter out mutual-tls if MTLS is not set
+ifeq ($(MTLS),)
+    FILTERED := $(filter-out mutual-tls.bats, $(TESTFILES))
+endif
+# Target all standard tests
+tests: $(FILTERED)
 
 cluster:
 	./scripts/cluster_k3d.sh create

--- a/tests/audit-scanner-installation.bats
+++ b/tests/audit-scanner-installation.bats
@@ -37,20 +37,20 @@ function assert_cronjob {
     fi
 }
 
-@test "[Audit Scanner] Reconfigure audit scanner" {
+@test "[Audit Scanner Installation] Reconfigure audit scanner" {
     helmer set kubewarden-controller --set auditScanner.cronJob.schedule="*/30 * * * *"
     run kubectl get cronjob -n $NAMESPACE
     assert_output -p audit-scanner
     assert_output -p "*/30 * * * *"
 }
 
-@test "[Audit Scanner] Audit scanner resources are cleaned with kubewarden" {
+@test "[Audit Scanner Installation] Audit scanner resources are cleaned with kubewarden" {
     kubewarden_uninstall
     assert_crds false
     assert_cronjob false
 }
 
-@test "[Audit Scanner] Install with CRDs pre-installed" {
+@test "[Audit Scanner Installation] Install with CRDs pre-installed" {
     # Install kubewarden with custom policyreport-crds
     kubectl create -f $CRD_BASE/wgpolicyk8s.io_policyreports.yaml
     kubectl create -f $CRD_BASE/wgpolicyk8s.io_clusterpolicyreports.yaml
@@ -75,7 +75,7 @@ function assert_cronjob {
     assert_crds false
 }
 
-@test "[Audit Scanner] Install with CRDs from Kubewarden Helm charts" {
+@test "[Audit Scanner Installation] Install with CRDs from Kubewarden Helm charts" {
     helmer reinstall
     assert_crds true
     assert_cronjob true

--- a/tests/mutual-tls.bats
+++ b/tests/mutual-tls.bats
@@ -1,4 +1,6 @@
 #!/usr/bin/env bats
+
+# mTLS has to be enabled on cluster level
 # https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
 
 setup() {
@@ -13,9 +15,6 @@ teardown_file() {
     kubectl delete ps mtls-pserver --ignore-not-found
     helmer reset kubewarden-controller
 }
-
-# mTLS has to be enabled on the cluster, use MTLS=1 to indicate that
-[[ "${MTLS:-}" =~ ^(false|0)?$ ]] && skip "Mutual TLS is disabled on cluster"
 
 function curlpod { kubectl exec curlpod -- curl -k --no-progress-meter $@; }
 


### PR DESCRIPTION
## Description

Bats allows to skip tests, but not on file level - `skip` command have to be called from test.
https://bats-core.readthedocs.io/en/stable/writing-tests.html#skip-easily-skip-tests

This PR remove skip from test and moves it on makefile leval.
Calling skip on file level causes bats error.

```
1..4
# bats warning: Executed 0 instead of expected 4 tests
make: *** [Makefile:47: mutual-tls.bats] Error 1
Error: Process completed with exit code 2.
```

This issue was not present when using bats npm package, but fails with ubuntu bats package.