### PR TITLE
Pin otel operator version to 0.86.4

### DIFF
--- a/tests/opentelemetry-tests.bats
+++ b/tests/opentelemetry-tests.bats
@@ -48,8 +48,10 @@ export -f get_metrics # required by retry command
 
     # OpemTelementry
     helm repo add --force-update open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+    # v0.86.4 - https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1648
     helm upgrade -i --wait my-opentelemetry-operator open-telemetry/opentelemetry-operator \
         --set "manager.collectorImage.repository=otel/opentelemetry-collector-contrib" \
+        --version 0.86.4 \
         -n open-telemetry --create-namespace
 
     # Prometheus


### PR DESCRIPTION
## Description

Pin otel version to 0.86.4 because of https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1648
Failing nightly & release tests: https://github.com/kubewarden/helm-charts/actions/runs/14696074981