### PR TITLE
Override otel operator version from env

### DIFF
--- a/tests/opentelemetry-tests.bats
+++ b/tests/opentelemetry-tests.bats
@@ -51,7 +51,7 @@ export -f get_metrics # required by retry command
     # v0.86.4 - https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1648
     helm upgrade -i --wait my-opentelemetry-operator open-telemetry/opentelemetry-operator \
         --set "manager.collectorImage.repository=otel/opentelemetry-collector-contrib" \
-        --version 0.86.4 \
+        --version "${OTEL_OPERATOR:-*}" \
         -n open-telemetry --create-namespace
 
     # Prometheus


### PR DESCRIPTION
## Description

We use latest stable OTEL Operator version, but it's occasionally broken.
Allowing to override OTEL version from env removes the need to commit & revert every time it breaks.

Currently all our tests are failing because of https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1648.
I will create `OTEL_OPERATOR` env variable in github action setup to pin version.