### PR TITLE
Pin OTEL to 0.86.4 for PRs

### DIFF
--- a/tests/opentelemetry-tests.bats
+++ b/tests/opentelemetry-tests.bats
@@ -51,7 +51,7 @@ export -f get_metrics # required by retry command
     # v0.86.4 - https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1648
     helm upgrade -i --wait my-opentelemetry-operator open-telemetry/opentelemetry-operator \
         --set "manager.collectorImage.repository=otel/opentelemetry-collector-contrib" \
-        --version "${OTEL_OPERATOR:-*}" \
+        --version "${OTEL_OPERATOR:-0.86.4}" \
         -n open-telemetry --create-namespace
 
     # Prometheus


### PR DESCRIPTION
## Description

Job can't access github repository variable if PR was created from a fork.
This change will pin OTEL also on PRs. 

https://github.com/orgs/community/discussions/44322