### PR TITLE
Add composite action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,23 @@
+name: "Run Makefile Target"
+description: "Triggers Makefile target in kubewarden-end-to-end-tests repository"
+
+inputs:
+  make:
+    description: "The Makefile target to run"
+    required: true
+    default: "check"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout kubewarden-end-to-end-tests
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ github.repository_owner }}/kubewarden-end-to-end-tests
+        ref: main
+        path: action-make
+
+    - name: Execute Makefile target
+      run: make ${{ inputs.make }}
+      working-directory: action-make
+      shell: bash

--- a/tests/policy.bats
+++ b/tests/policy.bats
@@ -26,7 +26,7 @@ POLICY_NUMBER=6
     wait_policies PolicyUniquelyReachable
 
     # Check we get the correct recommended policies number
-    kubectl --no-headers=true get ap,cap,apg,capg -A | wc -l | grep -qx $POLICY_NUMBER 
+    kubectl --no-headers=true get ap,cap,apg,capg -A | wc -l | grep -qx $POLICY_NUMBER
 }
 
 @test "[Recommended policies] Check that policies are enforced" {
@@ -78,7 +78,7 @@ POLICY_NUMBER=6
     # Deployment should fail because replicas < 3
     run ! kubectl create deployment cel-policy-test --image nginx --replicas 2
     assert_output --regexp '^error:.*admission webhook.*denied the request.*The number of replicas must be greater than or equal to 3$'
-    
+
     # Deployment should work because replicas >= 3
     kubectl create deployment cel-policy-test --image nginx --replicas 3
     kubectl delete deployment cel-policy-test


### PR DESCRIPTION
## Description

We reuse parts of e2e testsuite by duplicating code (cluster creation, rancher installation,...)
This is first part of cleanup. It allows to run e2e tests from composite action.

Example usage:
```yaml
uses: kubewarden/kubewarden-end-to-end-tests@main
with:
    make: rancher
env:
    RANCHER: ${{ env.RANCHER }}
    K3S: ${{ env.K3S_VERSION }}
```