### PR TITLE
Prepend e2e- to repos to prevent conflicts with existing ones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,5 +81,8 @@ all: clean cluster install tests
 check:
 	@yq --version | grep mikefarah > /dev/null || { echo "yq is not the correct, needs mikefarah/yq!"; exit 1; }
 	@jq --version > /dev/null || { echo "jq is not installed!"; exit 1; }
+	@docker --version > /dev/null || { echo "docker is not installed!"; exit 1; }
 	@k3d --version > /dev/null || { echo "k3d is not installed!"; exit 1; }
-	@bats --version > /dev/null || { echo "bats is not installed!"; exit 1; }
+	@kubectl version --client > /dev/null || { echo "kubectl is not installed!"; exit 1; }
+	@helm version > /dev/null || { echo "helm is not installed!"; exit 1; }
+	@bats --version > /dev/null || { echo "bats is not installed!"; }


### PR DESCRIPTION
## Description

@jvanz found an issue that broke search when system already had repo named `rancher-*`.

Fix this by prepending e2e to added repos. This makes it also more obvious how they were added.

@jhkrug found some missing dependencies, adding check for docker, kubectl and helm.
I made bats optional since it's not needed if we don't run tests.