### PR TITLE
Fix rancher installer chart names

### DIFF
--- a/scripts/rancher.sh
+++ b/scripts/rancher.sh
@@ -76,7 +76,7 @@ find_chart_by_constraints () {
 
     # Find charts from Q_REPOs with version matching Q_VER, ordered by version
     [[ "$q_ver" =~ $EXCLUDE_PATTERN ]] || local expattern="$EXCLUDE_PATTERN"
-    charts=$(helm search repo --fail-on-no-result -r "e2e-$q_repo.*/rancher" --version "$q_ver" --versions -o json |\
+    charts=$(helm search repo --fail-on-no-result -r "e2e-rancher-$q_repo.*/rancher" --version "$q_ver" --versions -o json |\
         jq -er --arg ex "${expattern:-}" '[.[] | select($ex == "" or (.version | test($ex) | not))] | unique_by(.name) | .[] | [.name, .version] | @tsv' | semsort -k2)
 
     # Same version can be in multiple repos (2.10.1 in prime, primerc, community)

--- a/tests/opentelemetry-tests.bats
+++ b/tests/opentelemetry-tests.bats
@@ -41,8 +41,8 @@ export -f get_metrics # required by retry command
 
 @test "[OpenTelemetry] Install OpenTelemetry, Prometheus, Jaeger" {
     # Required by OpenTelemetry
-    helm repo add jetstack https://charts.jetstack.io --force-update
-    helm upgrade -i --wait cert-manager jetstack/cert-manager \
+    helm repo add e2e-jetstack https://charts.jetstack.io --force-update
+    helm upgrade -i --wait cert-manager e2e-jetstack/cert-manager \
         -n cert-manager --create-namespace \
         --set crds.enabled=true
 


### PR DESCRIPTION
## Description

I added `e2e-` prefix to test repositories in https://github.com/kubewarden/kubewarden-end-to-end-tests/pull/175 but now repository does not match.

PR fixes prefix to `e2e-rancher-`.