### PR TITLE
Abort remaining tests on failure

### DIFF
--- a/tests/audit-scanner-installation.bats
+++ b/tests/audit-scanner-installation.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-    load ../helpers/helpers.sh
-    wait_pods -n kube-system
+    setup_helper
 }
 
 # Hardcode PolicyReports to v1alpha2 from clusterpolicyreports.wgpolicyk8s.io and not clusterpolicyreports.x-k8s.io
@@ -50,6 +49,7 @@ function assert_cronjob {
     assert_cronjob false
 }
 
+# bats test_tags=setup:--no-wait
 @test "[Audit Scanner Installation] Install with CRDs pre-installed" {
     # Install kubewarden with custom policyreport-crds
     kubectl create -f $CRD_BASE/wgpolicyk8s.io_policyreports.yaml
@@ -75,6 +75,7 @@ function assert_cronjob {
     assert_crds false
 }
 
+# bats test_tags=setup:--no-wait
 @test "[Audit Scanner Installation] Install with CRDs from Kubewarden Helm charts" {
     helmer reinstall
     assert_crds true

--- a/tests/audit-scanner.bats
+++ b/tests/audit-scanner.bats
@@ -1,14 +1,10 @@
 #!/usr/bin/env bats
 
 setup() {
-    load ../helpers/helpers.sh
-    wait_pods -n kube-system
+    setup_helper
 }
-
 teardown_file() {
-    load ../helpers/helpers.sh
-    kubectl delete pods --all
-    kubectl delete admissionpolicies,clusteradmissionpolicies --all -A
+    teardown_helper
     kubectl delete ns testing-audit-scanner --ignore-not-found
 }
 

--- a/tests/basic-end-to-end-tests.bats
+++ b/tests/basic-end-to-end-tests.bats
@@ -1,14 +1,10 @@
 #!/usr/bin/env bats
 
 setup() {
-    load ../helpers/helpers.sh
-    wait_pods
+    setup_helper
 }
-
 teardown_file() {
-    load ../helpers/helpers.sh
-    kubectl delete pods --all
-    kubectl delete ap,cap,capg --all -A
+    teardown_helper
 }
 
 @test "[Basic end-to-end tests] Helm app version is consistent" {

--- a/tests/context-aware-requests-tests.bats
+++ b/tests/context-aware-requests-tests.bats
@@ -1,14 +1,10 @@
 #!/usr/bin/env bats
 
 setup() {
-    load ../helpers/helpers.sh
-    wait_pods
+    setup_helper
 }
-
 teardown_file() {
-    load ../helpers/helpers.sh
-    kubectl delete pods --all
-    kubectl delete admissionpolicies,clusteradmissionpolicies --all -A
+    teardown_helper
 }
 
 # Same as in basic e2e tests?

--- a/tests/monitor-mode-tests.bats
+++ b/tests/monitor-mode-tests.bats
@@ -1,14 +1,10 @@
 #!/usr/bin/env bats
 
 setup() {
-    load ../helpers/helpers.sh
-    wait_pods
+    setup_helper
 }
-
 teardown_file() {
-    load ../helpers/helpers.sh
-    kubectl delete pods --all
-    kubectl delete admissionpolicies,clusteradmissionpolicies --all -A
+    teardown_helper
 }
 
 @test "[Monitor mode end-to-end tests] Install ClusterAdmissionPolicy in monitor mode" {

--- a/tests/mutating-requests-tests.bats
+++ b/tests/mutating-requests-tests.bats
@@ -1,14 +1,10 @@
 #!/usr/bin/env bats
 
 setup() {
-    load ../helpers/helpers.sh
-    wait_pods
+    setup_helper
 }
-
 teardown_file() {
-    load ../helpers/helpers.sh
-    kubectl delete pods --all
-    kubectl delete admissionpolicies,clusteradmissionpolicies --all -A
+    teardown_helper
 }
 
 # Same as in basic e2e tests?

--- a/tests/mutual-tls.bats
+++ b/tests/mutual-tls.bats
@@ -4,14 +4,10 @@
 # https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
 
 setup() {
-    load ../helpers/helpers.sh
-    wait_pods
+    setup_helper
 }
-
 teardown_file() {
-    load ../helpers/helpers.sh
-    kubectl delete pods --all
-    kubectl delete ap,cap --all
+    teardown_helper
     kubectl delete ps mtls-pserver --ignore-not-found
     helmer reset kubewarden-controller
 }

--- a/tests/namespaced-admission-policy-tests.bats
+++ b/tests/namespaced-admission-policy-tests.bats
@@ -1,14 +1,10 @@
 #!/usr/bin/env bats
 
 setup() {
-    load ../helpers/helpers.sh
-    wait_pods
+    setup_helper
 }
-
 teardown_file() {
-    load ../helpers/helpers.sh
-    kubectl delete pods --all
-    kubectl delete admissionpolicies,clusteradmissionpolicies --all -A
+    teardown_helper
 }
 
 @test "[Namespaced AdmissionPolicy] Test AdmissionPolicy in default NS" {

--- a/tests/opentelemetry-tests.bats
+++ b/tests/opentelemetry-tests.bats
@@ -5,14 +5,11 @@
 # kubectl port-forward -n jaeger svc/my-open-telemetry-query 16686:16686
 
 setup() {
-    load ../helpers/helpers.sh
-    wait_pods -n kube-system
+    setup_helper
 }
 
 teardown_file() {
-    load ../helpers/helpers.sh
-    kubectl delete admissionpolicies,clusteradmissionpolicies --all -A
-    kubectl delete pod nginx-privileged nginx-unprivileged --ignore-not-found
+    teardown_helper
 
     # Remote otel collector cleanup
     kubectl delete --ignore-not-found -f $RESOURCES_DIR/opentelemetry-jaeger.yaml

--- a/tests/policy.bats
+++ b/tests/policy.bats
@@ -1,14 +1,10 @@
 #!/usr/bin/env bats
 
 setup() {
-    load ../helpers/helpers.sh
-    wait_pods
+    setup_helper
 }
-
 teardown_file() {
-    load ../helpers/helpers.sh
-    kubectl delete pods --all
-    kubectl delete ap,cap,capg --all -A
+    teardown_helper
     kubectl delete ns shouldbeignored --ignore-not-found
     helmer reset kubewarden-defaults
 }

--- a/tests/private-registry-tests.bats
+++ b/tests/private-registry-tests.bats
@@ -2,8 +2,7 @@
 # https://github.com/kubewarden/kubewarden-controller/pull/421
 
 setup() {
-    load ../helpers/helpers.sh
-    wait_pods
+    setup_helper
 
     # FQDN=$(k3d node get k3d-$CLUSTER_NAME-server-0 -o json | jq -r 'first.IP.IP').nip.io
     FQDN=$(kubectl get nodes -l 'node-role.kubernetes.io/control-plane' -o custom-columns=INTERNAL-IP:.status.addresses[0].address --no-headers | tail -1).nip.io
@@ -14,8 +13,7 @@ setup() {
 }
 
 teardown_file() {
-    load ../helpers/helpers.sh
-    kubectl delete admissionpolicies,clusteradmissionpolicies --all -A
+    teardown_helper
 
     helmer set kubewarden-defaults \
         --set policyServer.imagePullSecret=null \

--- a/tests/reconfiguration-tests.bats
+++ b/tests/reconfiguration-tests.bats
@@ -1,14 +1,10 @@
 #!/usr/bin/env bats
 
 setup() {
-    load ../helpers/helpers.sh
-    wait_pods
+    setup_helper
 }
-
 teardown_file() {
-    load ../helpers/helpers.sh
-    kubectl delete pods --all
-    kubectl delete admissionpolicies,clusteradmissionpolicies --all -A
+    teardown_helper
 }
 
 @test "[Reconfiguration tests] Apply pod-privileged policy" {

--- a/tests/secure-supply-chain-tests.bats
+++ b/tests/secure-supply-chain-tests.bats
@@ -12,13 +12,10 @@
 CONFIGMAP_NAME="ssc-verification-config"
 
 setup() {
-    load ../helpers/helpers.sh
-    wait_pods
+    setup_helper
 }
-
 teardown_file() {
-    load ../helpers/helpers.sh
-    kubectl delete admissionpolicies,clusteradmissionpolicies --all -A
+    teardown_helper
     helmer reset kubewarden-defaults
     kubectl delete configmap -n $NAMESPACE $CONFIGMAP_NAME --ignore-not-found
 }

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -1,0 +1,6 @@
+setup_suite() {
+    # bats::on_failure hook requires >= 1.12.0
+    bats_require_minimum_version 1.11.0
+
+    load "../helpers/helpers.sh"
+}


### PR DESCRIPTION
Currently when some e2e test fails it calls teardown (clean up) and continues to execute remaining tests.

This change brings 2 improvements:
 - allows to use `KEEP=1` parameter which will skip teardown and keeps the resources in failed state.
 This will make it easier to debug failures found by e2e tests
 - skips any follow-up tests in case of failure
 - common setup & teardown was extracted to test helpers

To make skipping possible we need to schedule bats tests at once, not as separate makefile targets.
Makefile was updated with this change.

```bash
# To abort teardown use KEEP=1. Remaining tests are skipped by default on failure.
make tests KEEP=1
```

This feature requires bats 1.12.0, which is not packaged on ubuntu yet (github runners).
With older bats versions it works as before, tests won't abort on failure.