### PR TITLE
Fix rancher installation checks

### DIFF
--- a/scripts/rancher.sh
+++ b/scripts/rancher.sh
@@ -135,7 +135,8 @@ helm install rancher "$CHART_REPO" --version "$CHART_VER" \
     --set bootstrapPassword=sa \
     --wait --timeout=10m \
     --set replicas=1 \
-    ${stgregistry:+--set rancherImage=stgregistry.suse.com/rancher/rancher} && wait_for_rancher
+    ${stgregistry:+--set rancherImage=stgregistry.suse.com/rancher/rancher}
+wait_for_rancher
 
 # Check if Rancher has correct version and print URL
 helm get metadata rancher -n cattle-system -o json | jq -r '.version' | grep -qx "$CHART_VER"


### PR DESCRIPTION
"&&" prevents test from failing when helm installation fails

Example of test passing with rancher installation failure:
https://github.com/rancher/kubewarden-ui/actions/runs/15731058497/job/44332071804#step:8:79