### PR TITLE
Fix prometheus maximumStartupDurationSeconds error

### DIFF
--- a/resources/opentelemetry-prometheus.yaml
+++ b/resources/opentelemetry-prometheus.yaml
@@ -20,3 +20,6 @@ prometheus:
       endpoints:
         - port: metrics
           interval: 10s
+  # https://github.com/prometheus-community/helm-charts/issues/5690
+  prometheusSpec:
+    maximumStartupDurationSeconds: 300


### PR DESCRIPTION
Tests on older kubernetes fail on prometheus installation with message:

```
Release "prometheus" does not exist. Installing it now.
   Error: 1 error occurred:
   	* Prometheus.monitoring.coreos.com "prometheus-kube-prometheus-prometheus" is invalid: spec.maximumStartupDurationSeconds: Invalid value: 0: spec.maximumStartupDurationSeconds in body should be greater than or equal to 60
```

https://github.com/kubewarden/helm-charts/actions/runs/15754566385/job/44406955777