### PR TITLE
Generate test name prefix from test file

### DIFF
--- a/tests/audit-scanner-installation.bats
+++ b/tests/audit-scanner-installation.bats
@@ -36,21 +36,21 @@ function assert_cronjob {
     fi
 }
 
-@test "[Audit Scanner Installation] Reconfigure audit scanner" {
+@test "$(tfile) Reconfigure audit scanner" {
     helmer set kubewarden-controller --set auditScanner.cronJob.schedule="*/30 * * * *"
     run kubectl get cronjob -n $NAMESPACE
     assert_output -p audit-scanner
     assert_output -p "*/30 * * * *"
 }
 
-@test "[Audit Scanner Installation] Audit scanner resources are cleaned with kubewarden" {
+@test "$(tfile) Audit scanner resources are cleaned with kubewarden" {
     kubewarden_uninstall
     assert_crds false
     assert_cronjob false
 }
 
 # bats test_tags=setup:--no-wait
-@test "[Audit Scanner Installation] Install with CRDs pre-installed" {
+@test "$(tfile) Install with CRDs pre-installed" {
     # Install kubewarden with custom policyreport-crds
     kubectl create -f $CRD_BASE/wgpolicyk8s.io_policyreports.yaml
     kubectl create -f $CRD_BASE/wgpolicyk8s.io_clusterpolicyreports.yaml
@@ -76,7 +76,7 @@ function assert_cronjob {
 }
 
 # bats test_tags=setup:--no-wait
-@test "[Audit Scanner Installation] Install with CRDs from Kubewarden Helm charts" {
+@test "$(tfile) Install with CRDs from Kubewarden Helm charts" {
     helmer reinstall
     assert_crds true
     assert_cronjob true

--- a/tests/audit-scanner.bats
+++ b/tests/audit-scanner.bats
@@ -50,7 +50,7 @@ check_report_result() {
     fi
 }
 
-@test "[Audit Scanner] Install testing policies and resources" {
+@test "$(tfile) Install testing policies and resources" {
     # Make sure cronjob was created
     kubectl get cronjob -n $NAMESPACE audit-scanner
 
@@ -75,7 +75,7 @@ check_report_result() {
     trigger_audit_scan
 }
 
-@test "[Audit Scanner] Check cluster wide report results" {
+@test "$(tfile) Check cluster wide report results" {
     local r
 
     # Custom namespace should have failed the audit
@@ -102,7 +102,7 @@ check_report_result() {
     check_report_result "$r" pass clusterwide-safe-labels-for-pods
 }
 
-@test "[Audit Scanner] Delete some policies and retrigger audit scan" {
+@test "$(tfile) Delete some policies and retrigger audit scan" {
     delete_policy safe-labels-pods-policy.yaml
     delete_policy namespace-psa-label-enforcer-policy.yaml
     wait_policyserver
@@ -110,7 +110,7 @@ check_report_result() {
     trigger_audit_scan
 }
 
-@test "[Audit Scanner] Deleted ClusterAdmission policies are removed from audit results" {
+@test "$(tfile) Deleted ClusterAdmission policies are removed from audit results" {
     local r
 
     # Custom namespace pass removed
@@ -137,7 +137,7 @@ check_report_result() {
     check_report_result "$r" null clusterwide-safe-labels-for-pods
 }
 
-@test "[Audit Scanner] Delete all policy reports after all relevant policies" {
+@test "$(tfile) Delete all policy reports after all relevant policies" {
     delete_policy privileged-pod-policy.yaml
     delete_policy safe-labels-namespace.yaml
     wait_policyserver

--- a/tests/basic-tests.bats
+++ b/tests/basic-tests.bats
@@ -7,12 +7,12 @@ teardown_file() {
     teardown_helper
 }
 
-@test "[Basic end-to-end tests] Helm app version is consistent" {
+@test "$(tfile) Helm app version is consistent" {
     helm list -n $NAMESPACE -o json | jq 'map(.app_version) | unique | length == 1'
 }
 
 # Create pod-privileged policy to block CREATE & UPDATE of privileged pods
-@test "[Basic end-to-end tests] Apply pod-privileged policy that blocks CREATE & UPDATE" {
+@test "$(tfile) Apply pod-privileged policy that blocks CREATE & UPDATE" {
     apply_policy privileged-pod-policy.yaml
 
     # Launch unprivileged pod
@@ -24,7 +24,7 @@ teardown_file() {
 }
 
 # Update pod-privileged policy to block only UPDATE of privileged pods
-@test "[Basic end-to-end tests] Patch policy to block only UPDATE operation" {
+@test "$(tfile) Patch policy to block only UPDATE operation" {
     yq '.spec.rules[0].operations = ["UPDATE"]' $RESOURCES_DIR/policies/privileged-pod-policy.yaml | kubectl apply -f -
 
     # I can create privileged pods now
@@ -34,14 +34,14 @@ teardown_file() {
     kubefail_privileged label pod nginx-privileged x=y
 }
 
-@test "[Basic end-to-end tests] Delete ClusterAdmissionPolicy" {
+@test "$(tfile) Delete ClusterAdmissionPolicy" {
     delete_policy privileged-pod-policy.yaml
 
     # I can update privileged pods now
     kubectl label pod nginx-privileged x=y
 }
 
-@test "[Basic end-to-end tests] Apply mutating psp-user-group AdmissionPolicy" {
+@test "$(tfile) Apply mutating psp-user-group AdmissionPolicy" {
     apply_policy psp-user-group-policy.yaml
 
     # Policy should mutate pods
@@ -52,7 +52,7 @@ teardown_file() {
     delete_policy psp-user-group-policy.yaml
 }
 
-@test "[Basic end-to-end tests] Launch & scale second policy server" {
+@test "$(tfile) Launch & scale second policy server" {
     create_policyserver e2e-tests
     wait_for policyserver e2e-tests --for=condition=ServiceReconciled
 

--- a/tests/context-aware-requests-tests.bats
+++ b/tests/context-aware-requests-tests.bats
@@ -8,7 +8,7 @@ teardown_file() {
 }
 
 # Same as in basic e2e tests?
-@test "[Context Aware Policy tests] Test mutating a Pod" {
+@test "$(tfile) Test mutating a Pod" {
     apply_policy context-aware-policy.yaml
 
     # Create Pod with the right annotation

--- a/tests/monitor-mode-tests.bats
+++ b/tests/monitor-mode-tests.bats
@@ -7,11 +7,11 @@ teardown_file() {
     teardown_helper
 }
 
-@test "[Monitor mode end-to-end tests] Install ClusterAdmissionPolicy in monitor mode" {
+@test "$(tfile) Install ClusterAdmissionPolicy in monitor mode" {
     apply_policy privileged-pod-policy-monitor.yaml
 }
 
-@test "[Monitor mode end-to-end tests] Monitor mode should only log event" {
+@test "$(tfile) Monitor mode should only log event" {
     kubectl run nginx-privileged --image=nginx:alpine --privileged
     run kubectl logs -n $NAMESPACE -l app.kubernetes.io/instance=policy-server-default
     assert_output -p "policy evaluation (monitor mode)"
@@ -20,14 +20,14 @@ teardown_file() {
     kubectl delete pod nginx-privileged
 }
 
-@test "[Monitor mode end-to-end tests] Transition to protect should block events" {
+@test "$(tfile) Transition to protect should block events" {
     apply_policy privileged-pod-policy.yaml
 
     # Launch privileged pod (should fail)
     kubefail_privileged run pod-privileged --image=rancher/pause:3.2 --privileged
 }
 
-@test "[Monitor mode end-to-end tests] Transition from protect to monitor should be disallowed" {
+@test "$(tfile) Transition from protect to monitor should be disallowed" {
     run kubectl apply -f "$RESOURCES_DIR/policies/privileged-pod-policy-monitor.yaml"
     assert_failure
     assert_output --partial "field cannot transition from protect to monitor. Recreate instead."

--- a/tests/mutating-requests-tests.bats
+++ b/tests/mutating-requests-tests.bats
@@ -8,7 +8,7 @@ teardown_file() {
 }
 
 # Same as in basic e2e tests?
-@test "[Mutation request tests] Test psp-user-group policy with mutating flag enabled" {
+@test "$(tfile) Test psp-user-group policy with mutating flag enabled" {
     apply_policy mutate-policy-with-flag-enabled.yaml
 
     # New pod should be mutated by the policy
@@ -20,7 +20,7 @@ teardown_file() {
     delete_policy mutate-policy-with-flag-enabled.yaml
 }
 
-@test "[Mutation request tests] Test psp-user-group policy with mutating flag disabled" {
+@test "$(tfile) Test psp-user-group policy with mutating flag disabled" {
     apply_policy mutate-policy-with-flag-disabled.yaml
 
     # New pod should be rejected by psp-user-group-policy

--- a/tests/mutual-tls.bats
+++ b/tests/mutual-tls.bats
@@ -26,7 +26,7 @@ function check_service_mtls {
     assert_output --regexp "error.*alert certificate required"
 }
 
-@test "[Mutual TLS] Prepare resources" {
+@test "$(tfile) Prepare resources" {
     # Create secondary Policy Server
     create_policyserver mtls-pserver
 
@@ -36,14 +36,14 @@ function check_service_mtls {
     kubectl cp resources/mtls curlpod:/mtls
 }
 
-@test "[Mutual TLS] Enable mTLS" {
+@test "$(tfile) Enable mTLS" {
     helm get values -n $NAMESPACE kubewarden-controller -o json | jq -e '.mTLS.enable == true' && skip "mTLS was enabled during installation"
 
     kubectl get cm -n $NAMESPACE mtlscm &>/dev/null || kubectl create cm -n $NAMESPACE mtlscm --from-file="client-ca.crt=$RESOURCES_DIR/mtls/rootCA.crt"
     helmer set kubewarden-controller --set mTLS.enable=true --set mTLS.configMapName=mtlscm
 }
 
-@test "[Mutual TLS] Check mTLS" {
+@test "$(tfile) Check mTLS" {
     # Check mTLS is enabled in kubernetes
     kubectl get nodes -l node-role.kubernetes.io/control-plane -o yaml | grep -F "admission-control-config-file"
     # Check default PS logs
@@ -59,7 +59,7 @@ function check_service_mtls {
     run ! kuberun -l cost-center=lbl
 }
 
-@test "[Mutual TLS] Disable mTLS" {
+@test "$(tfile) Disable mTLS" {
     helmer set kubewarden-controller --set mTLS.enable=false
 
     # Talk to services without a certificate

--- a/tests/namespaced-admission-policy-tests.bats
+++ b/tests/namespaced-admission-policy-tests.bats
@@ -7,7 +7,7 @@ teardown_file() {
     teardown_helper
 }
 
-@test "[Namespaced AdmissionPolicy] Test AdmissionPolicy in default NS" {
+@test "$(tfile) Test AdmissionPolicy in default NS" {
     apply_policy policy-pod-privileged.yaml
 
     # Privileged pod in the default namespace (should fail)
@@ -24,7 +24,7 @@ teardown_file() {
     kubectl delete pod nginx-unprivileged
 }
 
-@test  "[Namespaced AdmissionPolicy] Update policy to check only UPDATE operations" {
+@test  "$(tfile) Update policy to check only UPDATE operations" {
     yq '.spec.rules[0].operations = ["UPDATE"]' $RESOURCES_DIR/policies/policy-pod-privileged.yaml | kubectl apply -f -
 
     # I can create privileged pods now
@@ -35,7 +35,7 @@ teardown_file() {
     kubectl delete pod nginx-privileged
 }
 
-@test "[Namespaced AdmissionPolicy] Delete AdmissionPolicy to check restrictions are removed" {
+@test "$(tfile) Delete AdmissionPolicy to check restrictions are removed" {
     delete_policy policy-pod-privileged.yaml
 
     # I can create privileged pods

--- a/tests/opentelemetry-tests.bats
+++ b/tests/opentelemetry-tests.bats
@@ -36,7 +36,7 @@ function get_metrics {
 }
 export -f get_metrics # required by retry command
 
-@test "[OpenTelemetry] Install OpenTelemetry, Prometheus, Jaeger" {
+@test "$(tfile) Install OpenTelemetry, Prometheus, Jaeger" {
     # Required by OpenTelemetry
     helm repo add e2e-jetstack https://charts.jetstack.io --force-update
     helm upgrade -i --wait cert-manager e2e-jetstack/cert-manager \
@@ -73,7 +73,7 @@ export -f get_metrics # required by retry command
     helmer set kubewarden-defaults --set recommendedPolicies.enabled=True
 }
 
-@test "[OpenTelemetry] Kubewarden containers have sidecars & metrics" {
+@test "$(tfile) Kubewarden containers have sidecars & metrics" {
     # Controller is restarted to get sidecar
     wait_pods -n $NAMESPACE
 
@@ -94,7 +94,7 @@ export -f get_metrics # required by retry command
     retry 'test $(get_metrics kubewarden-controller-metrics-service | wc -l) -gt 1'
 }
 
-@test "[OpenTelemetry] Audit scanner runs should generate metrics" {
+@test "$(tfile) Audit scanner runs should generate metrics" {
     kubectl get cronjob -n $NAMESPACE audit-scanner
 
     # Launch unprivileged & privileged pods
@@ -114,7 +114,7 @@ export -f get_metrics # required by retry command
     delete_policy namespace-label-propagator-policy.yaml
 }
 
-@test "[OpenTelemetry] Disabling telemetry should remove sidecars & metrics" {
+@test "$(tfile) Disabling telemetry should remove sidecars & metrics" {
     helmer set kubewarden-controller \
         --set telemetry.metrics=False \
         --set telemetry.tracing=False

--- a/tests/policy.bats
+++ b/tests/policy.bats
@@ -12,7 +12,7 @@ teardown_file() {
 # Number of policies included in the recommended policies
 POLICY_NUMBER=6
 
-@test "[Recommended policies] Install policies in protect mode" {
+@test "$(tfile) Install recommended policies in protect mode" {
     helmer set kubewarden-defaults \
         --set recommendedPolicies.enabled=True \
         --set recommendedPolicies.defaultPolicyMode=protect \
@@ -25,7 +25,7 @@ POLICY_NUMBER=6
     kubectl --no-headers=true get ap,cap,apg,capg -A | wc -l | grep -qx $POLICY_NUMBER
 }
 
-@test "[Recommended policies] Check that policies are enforced" {
+@test "$(tfile) Recommended policies are enforced" {
     # Test privileged pod (should fail)
     kubefail_privileged run pod-privileged --image=rancher/pause:3.2 --privileged
 
@@ -54,13 +54,13 @@ POLICY_NUMBER=6
     kuberun --privileged -n shouldbeignored
 }
 
-@test "[Recommended policies] Disable policies & run privileged pod" {
+@test "$(tfile) Disable recommended policies" {
     helmer set kubewarden-defaults --set recommendedPolicies.enabled=False
     kubectl run pod-privileged --image=rancher/pause:3.2 --privileged
     kubectl delete pod pod-privileged
 }
 
-@test "[Rego policy] Apply rego policy to block nginx image usage" {
+@test "$(tfile) Rego policy blocks nginx image usage" {
     apply_policy rego-block-image-policy.yaml
 
     run ! kuberun --image=nginx
@@ -68,7 +68,7 @@ POLICY_NUMBER=6
     delete_policy rego-block-image-policy.yaml
 }
 
-@test "[CEL policies] Apply CEL policy to block deployment with replicas < 3" {
+@test "$(tfile) CEL policy blocks deployment with replicas < 3" {
     apply_policy cel-policy.yaml
 
     # Deployment should fail because replicas < 3
@@ -81,7 +81,7 @@ POLICY_NUMBER=6
     delete_policy cel-policy.yaml
 }
 
-@test "[Policy group] Apply policy group to block privileged escalation and shared pid namespace pods" {
+@test "$(tfile) Group policy blocks privileged escalation and shared pid namespace pods" {
     apply_policy policy-group-escalation-shared-pid.yaml
 
     # I can not create pod using privileged escalation only

--- a/tests/private-registry-tests.bats
+++ b/tests/private-registry-tests.bats
@@ -27,7 +27,7 @@ teardown_file() {
 }
 
 # https://medium.com/geekculture/deploying-docker-registry-on-kubernetes-3319622b8f32
-@test "[Private Registry] Generate AUTH and start registry" {
+@test "$(tfile) Generate AUTH and start registry" {
     certdir="$BATS_RUN_TMPDIR/certs/"
     generate_certs "$certdir" "$FQDN"
 
@@ -44,7 +44,7 @@ teardown_file() {
     wait_rollout 'deploy/registry'
 }
 
-@test "[Private Registry] Pull & Push policy to registry" {
+@test "$(tfile) Pull & Push policy to registry" {
     jq -n --arg r $REGISTRY \
         '{"auths": {($r): {"auth": "dGVzdHVzZXI6dGVzdHBhc3N3b3Jk"}}}' > "$BATS_RUN_TMPDIR/config.json"
     jq -n --arg r $REGISTRY --arg crt "$BATS_RUN_TMPDIR/certs/rootCA.crt" \
@@ -57,7 +57,7 @@ teardown_file() {
 }
 
 # https://docs.kubewarden.io/operator-manual/policy-servers/private-registry
-@test "[Private Registry] Set up policy server access to registry" {
+@test "$(tfile) Set up policy server access to registry" {
     # Create secret to access registry
     kubectl --namespace kubewarden create secret docker-registry secret-registry-docker \
       --docker-username=testuser \
@@ -73,7 +73,7 @@ teardown_file() {
     helm get values -n $NAMESPACE kubewarden-defaults
 }
 
-@test "[Private Registry] Check I can deploy policy from auth registry" {
+@test "$(tfile) Check I can deploy policy from auth registry" {
     policy="$BATS_RUN_TMPDIR/private-policy.yaml"
 
     kwctl scaffold manifest --type=ClusterAdmissionPolicy $PUB_POLICY |\

--- a/tests/reconfiguration-tests.bats
+++ b/tests/reconfiguration-tests.bats
@@ -7,20 +7,20 @@ teardown_file() {
     teardown_helper
 }
 
-@test "[Reconfiguration tests] Apply pod-privileged policy" {
+@test "$(tfile) Apply pod-privileged policy" {
     apply_policy privileged-pod-policy.yaml
 }
 
-@test "[Reconfiguration tests] Reconfigure Kubewarden stack" {
+@test "$(tfile) Reconfigure Kubewarden stack" {
     helmer set kubewarden-controller --values=$RESOURCES_DIR/reconfiguration-values.yaml
     wait_for --for=condition="PolicyActive" clusteradmissionpolicies --all
 }
 
-@test "[Reconfiguration tests] Apply psp-user-group policy" {
+@test "$(tfile) Apply psp-user-group policy" {
     apply_policy psp-user-group-policy.yaml
 }
 
-@test "[Reconfiguration tests] Test that pod-privileged policy works" {
+@test "$(tfile) Test that pod-privileged policy works" {
     # Launch unprivileged pod
     kubectl run pause-unprivileged --image rancher/pause:3.2
     wait_for pod pause-unprivileged

--- a/tests/secure-supply-chain-tests.bats
+++ b/tests/secure-supply-chain-tests.bats
@@ -37,14 +37,14 @@ function get_policy_server_status {
 
 # Configure kubewarden to check policy signatures
 # https://docs.kubewarden.io/distributing-policies/secure-supply-chain#configuring-the-policy-server-to-check-policy-signatures
-@test "[Secure Supply Chain tests] Enable" {
+@test "$(tfile) Enable" {
     # policyserver needs configmap to start in verification mode
     create_configmap <(kwctl scaffold verification-config)
     helmer set kubewarden-defaults --set policyServer.verificationConfig=$CONFIGMAP_NAME
     kubectl get policyserver default -o json | jq -e --arg cmname $CONFIGMAP_NAME '.spec.verificationConfig == $cmname'
 }
 
-@test "[Secure Supply Chain tests] Trusted policy should not block policy server" {
+@test "$(tfile) Trusted policy should not block policy server" {
     create_configmap $RESOURCES_DIR/secure-supply-chain-cm.yaml
 
     # Policy Server should start fine
@@ -58,7 +58,7 @@ function get_policy_server_status {
     delete_policy policy-pod-privileged.yaml
 }
 
-@test "[Secure Supply Chain tests] Untrusted policy should block policy server to run" {
+@test "$(tfile) Untrusted policy should block policy server to run" {
     create_configmap $RESOURCES_DIR/secure-supply-chain-cm-restricted.yaml
 
     # Policy Server startup should fail

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -1,3 +1,7 @@
+# Output: [basic-tests.bats]
+tfile() { echo -n "[${BATS_TEST_FILENAME##*/}]"; }
+export -f tfile
+
 setup_suite() {
     # bats::on_failure hook requires >= 1.12.0
     bats_require_minimum_version 1.11.0


### PR DESCRIPTION
## Description

Our tests use `[prefix]` to identify test area, like:
```
ok 5 [Audit Scanner] Delete all policy reports after all relevant policies in 50814ms
ok 6 [Basic end-to-end tests] Helm app version is consistent in 113ms
ok 7 [Basic end-to-end tests] Apply pod-privileged policy that blocks CREATE & UPDATE in 42570ms
ok 8 [Basic end-to-end tests] Patch policy to block only UPDATE operation in 822ms
ok 9 [Basic end-to-end tests] Delete ClusterAdmissionPolicy in 286ms
```

This is hardcoded and we need to grep test files to find where is the failing one.

I changed this to generate prefix with file name of a test:
```
ok 1 [basic-tests.bats] Helm app version is consistent [158]
ok 2 [basic-tests.bats] Apply pod-privileged policy that blocks CREATE & UPDATE [44014]
ok 3 [basic-tests.bats] Patch policy to block only UPDATE operation [512]
ok 4 [basic-tests.bats] Delete ClusterAdmissionPolicy [390]
ok 5 [basic-tests.bats] Apply mutating psp-user-group AdmissionPolicy [90348]
```
