### PR TITLE
Fix output redirection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MKFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 TESTS_DIR := $(MKFILE_DIR)tests
 RESOURCES_DIR := $(MKFILE_DIR)resources
 
-NAMESPACE ?= $(shell helm status -n cattle-system rancher &>/dev/null && echo "cattle-kubewarden-system" || echo "kubewarden")
+NAMESPACE ?= $(shell helm status -n cattle-system rancher >/dev/null 2>&1 && echo "cattle-kubewarden-system" || echo "kubewarden")
 CLUSTER_CONTEXT ?= $(shell kubectl config current-context)
 
 export NAMESPACE


### PR DESCRIPTION
## Description

Makefile on github runners defaults to DASH shell, but `&>` redirection is BASH specific.
Update redirection syntax to be posix compliant.

Fix for: https://github.com/kubewarden/helm-charts/actions/runs/16035726717
Test run: https://github.com/kravciak/helm-charts/actions/runs/16044383477
