### PR TITLE
Set default OTEL operator version in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,10 @@ RESOURCES_DIR := $(MKFILE_DIR)resources
 NAMESPACE ?= $(shell helm status -n cattle-system rancher >/dev/null 2>&1 && echo "cattle-kubewarden-system" || echo "kubewarden")
 CLUSTER_CONTEXT ?= $(shell kubectl config current-context)
 
-export NAMESPACE
+# Should match version in https://docs.kubewarden.io/reference/dependency-matrix
+OTEL_OPERATOR ?= 0.92.3
+
+export NAMESPACE OTEL_OPERATOR
 
 # ==================================================================================================
 # Optional arguments for scripts

--- a/tests/opentelemetry-tests.bats
+++ b/tests/opentelemetry-tests.bats
@@ -45,10 +45,9 @@ export -f get_metrics # required by retry command
 
     # OpemTelementry
     helm repo add --force-update open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
-    # v0.86.4 - https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1648
     helm upgrade -i --wait my-opentelemetry-operator open-telemetry/opentelemetry-operator \
         --set "manager.collectorImage.repository=otel/opentelemetry-collector-contrib" \
-        --version "${OTEL_OPERATOR:-0.86.4}" \
+        --version "${OTEL_OPERATOR:-*}" \
         -n open-telemetry --create-namespace
 
     # Prometheus


### PR DESCRIPTION
## Description

Do not hardcode default OTEL operator version directly in a test file, use makefile for this.

Related to https://github.com/kubewarden/kubewarden-end-to-end-tests/issues/110