### PR TITLE
Use official extension repo on rancher prime

### DIFF
--- a/resources/rancher/repo-rancher-ui-plugins.yaml
+++ b/resources/rancher/repo-rancher-ui-plugins.yaml
@@ -1,0 +1,8 @@
+# Rancher official extesion repository
+apiVersion: catalog.cattle.io/v1
+kind: ClusterRepo
+metadata:
+  name: rancher-ui-plugins
+spec:
+  gitBranch: main
+  gitRepo: https://github.com/rancher/ui-plugin-charts


### PR DESCRIPTION
## Description

Use official repository to install extension on rancher prime and github repository on community..
Currently it's always using github repository.

This will match the workflow we have in ui extension tests.