### PR TITLE
Add DRY=1 parameter to only print component versions

### DIFF
--- a/scripts/cluster_k3d.sh
+++ b/scripts/cluster_k3d.sh
@@ -19,13 +19,14 @@ BASEDIR=$(dirname "${BASH_SOURCE[0]}")
 
 # Create new cluster
 if [ "${1:-}" == 'create' ]; then
-    precheck cluster || exit 1
+    [ -v DRY ] || { precheck cluster || exit 1; }
 
     # Complete partial K3S version from dockerhub v1.30 -> v1.30.5-k3s1
     if [[ ! $K3S =~ ^v[0-9.]+-k3s[0-9]$ ]]; then
         K3S=$(curl -L -s "https://registry.hub.docker.com/v2/repositories/rancher/k3s/tags?page_size=20&name=$K3S" | jq -re 'first(.results[].name | select(test("^v[0-9.]+-k3s[0-9]$")))')
         echo "K3S version: $K3S"
     fi
+    [ -v DRY ] && exit 0
 
     # Generate certificates
     if [ -n "${MTLS:-}" ]; then

--- a/scripts/helmer.sh
+++ b/scripts/helmer.sh
@@ -327,10 +327,11 @@ case $1 in
         load_env;;&
 
     # Handle kubewarden requirements
-    in|install|up|upgrade) setup_requirements;;&
+    in|install|up|upgrade) [ -v DRY ] || setup_requirements;;&
 
     # Call action function
     in|install)
+        [ -v DRY ] && { echo "Install $VERSION: ($(print_version_map))"; exit 0; }
         precheck kubewarden || exit 1
         do_install${RANCHER:+_on_rancher} "${@:2}";;
     up|upgrade) do_upgrade "${@:2}";;

--- a/scripts/rancher.sh
+++ b/scripts/rancher.sh
@@ -125,7 +125,7 @@ wait_for_rancher() {
 # ==================================================================================================
 # Main script
 
-precheck rancher || exit 1
+[ -v DRY ] || { precheck rancher || exit 1; }
 
 helm_add_repositories
 
@@ -143,6 +143,8 @@ fi
 RANCHER_FQDN=${RANCHER_FQDN:-$(kubectl get svc traefik -n kube-system -o jsonpath='{.status.loadBalancer.ingress[0].ip}').nip.io}
 # Required for prime Alpha & RC
 [[ $CHART_REPO =~ ^e2e-rancher-prime(alpha|rc) ]] && stgregistry=1
+
+[ -v DRY ] && exit 0
 
 # Install cert-manager
 helm install --wait cert-manager e2e-jetstack/cert-manager -n cert-manager --create-namespace --set crds.enabled=true


### PR DESCRIPTION
## Description

Allow to run with `DRY=1` to only print components that would be pulled.
We occasionally use this to find rancher repository or kubewarden component versions.

```bash
~ make rancher RANCHER=2.11 DRY=1
./scripts/rancher.sh
QUERY: -:2.11
CHART: e2e-rancher-prime/rancher:2.11.4

~ make install VERSION=1.26 DRY=1
./scripts/helmer.sh install
Install v1.26.0: (app:v1.26.0 crds:1.18.0 controller:5.4.0 defaults:3.4.0)
```