### PR TITLE
Bump OTEL operator to 0.93.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ NAMESPACE ?= $(shell helm status -n cattle-system rancher >/dev/null 2>&1 && ech
 CLUSTER_CONTEXT ?= $(shell kubectl config current-context)
 
 # Should match version in https://docs.kubewarden.io/reference/dependency-matrix
-OTEL_OPERATOR ?= 0.92.3
+OTEL_OPERATOR ?= 0.93.0
 
 export NAMESPACE OTEL_OPERATOR
 


### PR DESCRIPTION
## Description

I updated github variable for nightly jobs to 0.93.0 and tests passed fine.
Changing default for PR tests.