### PR TITLE
fix: Limit app version check to major.minor

### DIFF
--- a/scripts/rancher.sh
+++ b/scripts/rancher.sh
@@ -166,7 +166,7 @@ helm install rancher "$CHART_REPO" --version "$CHART_VER" \
     --namespace cattle-system --create-namespace \
     --set hostname="$RANCHER_FQDN" \
     --set bootstrapPassword=sa \
-    --wait --timeout=10m \
+    --wait --timeout=15m \
     --set replicas=1 \
     ${stgregistry:+--set rancherImage=stgregistry.suse.com/rancher/rancher} \
     ${stgregistry:+--set extraEnv[0].name=CATTLE_AGENT_IMAGE} \

--- a/tests/basic-tests.bats
+++ b/tests/basic-tests.bats
@@ -7,8 +7,9 @@ teardown_file() {
     teardown_helper
 }
 
+# Check that MAJOR.MINOR of app version is consistent
 @test "$(tfile) Helm app version is consistent" {
-    helm list -n $NAMESPACE -o json | jq 'map(.app_version) | unique | length == 1'
+    helm list -n $NAMESPACE -o json | jq 'map(.app_version | split(".")[0:2] | join(".")) | unique | length == 1'
 }
 
 # Create pod-privileged policy to block CREATE & UPDATE of privileged pods


### PR DESCRIPTION
## Description

Currently we check that MAJOR.MINOR.PATCH versions of controller/crds/defaults are consistent.
According to [our docs](https://docs.kubewarden.io/reference/upgrade-path#stack-version-compatibility-among-components) only MAJOR.MINOR has to match. Update this check to match this rule.