### PR TITLE
Check hauler matches versions in charts

### DIFF
--- a/tests/basic-tests.bats
+++ b/tests/basic-tests.bats
@@ -7,8 +7,56 @@ teardown_file() {
     teardown_helper
 }
 
-@test "$(tfile) Helm app version is consistent" {
-    helm list -n $NAMESPACE -o json | jq 'map(.app_version) | unique | length == 1'
+# Get versions from hauler_manifest
+# Usage: haul_get section selector
+haul_get() {
+    local n="$1" # name of the hauler_manifest section
+    local q="$2" # name of the image or chart to query
+    local y      # yaml from section $n
+
+    y=$(n=$n yq -e 'select(.metadata.name == env(n)).spec | .images + .charts' "$CHARTS_LOCATION/hauler_manifest.yaml")
+    case "$n" in
+        *not-signed-images|*container-images|*policies)
+            q=$q yq -e '.[].name | select(contains(env(q)+":")) | split(":")[1]' <<<"$y";;
+        *helm-charts)
+            q=$q yq -e '.[] | select(.name == env(q)).version' <<<"$y";;
+        *)
+            echo "Unknown hauler section: $n" >&2; return 1;;
+    esac
+}
+
+# Get versions from helm charts
+# Usage: helm_get chart-name [yq-query]
+helm_get() {
+    local chart=$CHARTS_LOCATION/$1
+    yq -e "${2:-.}" <(helm show values "$chart"; helm show chart "$chart")
+}
+
+@test "$(tfile) Version checks" {
+    # Helm app version is consistent
+    helm list -n "$NAMESPACE" -o json | jq 'map(.app_version) | unique | length == 1'
+
+    # Hauler manifest versions for PRs
+    if [[ "$CHARTS_LOCATION" == */* ]]; then
+        # Helm Charts
+        for chart in kubewarden-crds kubewarden-controller kubewarden-defaults; do
+            test "$(haul_get kubewarden-helm-charts $chart)" = "$(helm_get $chart '.version')"
+        done
+        test "$(haul_get kubewarden-helm-charts policy-reporter)" = "$(helm_get kubewarden-controller '.dependencies[].version')"
+        # Signed images
+        test "$(haul_get kubewarden-container-images kubewarden-controller)" = "$(helm_get kubewarden-controller '.image.tag')"
+        test "$(haul_get kubewarden-container-images audit-scanner)" = "$(helm_get kubewarden-controller '.auditScanner.image.tag')"
+        test "$(haul_get kubewarden-container-images policy-server)" = "$(helm_get kubewarden-defaults '.policyServer.image.tag')"
+        # Unsigned images
+        test "$(haul_get kubewarden-not-signed-images policy-reporter)" = "$(helm_get kubewarden-controller '.policy-reporter.image.tag')"
+        test "$(haul_get kubewarden-not-signed-images policy-reporter-ui)" = "$(helm_get kubewarden-controller '.policy-reporter.ui.image.tag')"
+        test "$(haul_get kubewarden-not-signed-images kuberlr-kubectl)" = "$(helm_get kubewarden-controller '.preDeleteJob.image.tag')"
+        # Policies
+        for policy in allow-privilege-escalation-psp capabilities-psp host-namespaces-psp hostpaths-psp pod-privileged user-group-psp; do
+            test "$(haul_get kubewarden-policies $policy)" \
+                = "$(helm_get kubewarden-defaults | p=$policy yq '.recommendedPolicies[].module? | select(.repository == "*"+env(p)).tag')"
+        done
+    fi
 }
 
 # Create pod-privileged policy to block CREATE & UPDATE of privileged pods
@@ -25,7 +73,7 @@ teardown_file() {
 
 # Update pod-privileged policy to block only UPDATE of privileged pods
 @test "$(tfile) Patch policy to block only UPDATE operation" {
-    yq '.spec.rules[0].operations = ["UPDATE"]' $RESOURCES_DIR/policies/privileged-pod-policy.yaml | kubectl apply -f -
+    yq '.spec.rules[0].operations = ["UPDATE"]' "$RESOURCES_DIR/policies/privileged-pod-policy.yaml" | kubectl apply -f -
 
     # I can create privileged pods now
     kubectl run nginx-privileged --image=nginx:alpine --privileged


### PR DESCRIPTION
## Description

We bumped helm charts [manually](https://github.com/kubewarden/helm-charts/pull/770), but forgot to update hauler manifest.
@jvanz noticed & fixed the issue, this test should prevent it to happen again.

Based on https://suse.slack.com/archives/C02DBSK7HC1/p1757424799515989