### PR TITLE
fix: Use default value also for empty strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ NAMESPACE ?= $(shell helm status -n cattle-system rancher >/dev/null 2>&1 && ech
 CLUSTER_CONTEXT ?= $(shell kubectl config current-context)
 
 # Should match version in https://docs.kubewarden.io/reference/dependency-matrix
-OTEL_OPERATOR ?= 0.93.0
+OTEL_OPERATOR := $(or $(OTEL_OPERATOR),0.93.0)
 
 export NAMESPACE OTEL_OPERATOR
 

--- a/tests/opentelemetry-tests.bats
+++ b/tests/opentelemetry-tests.bats
@@ -43,7 +43,7 @@ export -f get_metrics # required by retry command
         -n cert-manager --create-namespace \
         --set crds.enabled=true
 
-    # OpemTelementry
+    # OpenTelemetry
     helm repo add --force-update open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
     helm upgrade -i --wait my-opentelemetry-operator open-telemetry/opentelemetry-operator \
         --set "manager.collectorImage.repository=otel/opentelemetry-collector-contrib" \


### PR DESCRIPTION
Jobs schedules by pull_request from other repository has vars.OTEL_OPERATOR empty, but still set in env. Default is used only when OTEL_OPERATOR is unset, which means it installs latest OTEL.

  run: |
    make tests
  env:
    OTEL_OPERATOR: ${{ vars.OTEL_OPERATOR }}

This change will use default value when OTEL_OPERATOR is unset or empty string.
