### PR TITLE
Add option to enable kubewarden user CRs in backup

### DIFF
--- a/tests/ginkgo-e2e/e2e/suite_test.go
+++ b/tests/ginkgo-e2e/e2e/suite_test.go
@@ -117,6 +117,7 @@ func InstallBackupOperator(k *kubectl.Kubectl) {
 			flags = append(flags,
 				"--set", "persistence.enabled=true",
 				"--set", "persistence.storageClass=local-path",
+				"--set", "optionalResources.kubewardenUserCRs.enabled=true",
 			)
 		}
 


### PR DESCRIPTION
## Description

Add new option optionalResources.kubewardenUserCRs.enabled=true to backup user custom resources
