### PR TITLE
Bump OTEL_OPERATOR to 0.97.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ NAMESPACE ?= $(shell helm status -n cattle-system rancher >/dev/null 2>&1 && ech
 CLUSTER_CONTEXT ?= $(shell kubectl config current-context)
 
 # Should match version in https://docs.kubewarden.io/reference/dependency-matrix
-OTEL_OPERATOR := $(or $(OTEL_OPERATOR),0.93.0)
+OTEL_OPERATOR := $(or $(OTEL_OPERATOR),0.97.1)
 
 export NAMESPACE OTEL_OPERATOR
 


### PR DESCRIPTION
- Use ghcr.io for collectorImage

In the v0.123.1 Collector release stopped pushing images to Dockerhub because of new rate limit changes.

https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/UPGRADING.md#0864-to-0870

- Sidecar runs in initContainer since otel v0.132.0 On release notes Enhancements section there is mention of collector changed to use native sidecar on k8s 1.29+

https://github.com/open-telemetry/opentelemetry-operator/releases/tag/v0.132.0
