### PR TITLE
Remove hardecoded policy-server version

### DIFF
--- a/tests/ginkgo-e2e/e2e/backup-restore_test.go
+++ b/tests/ginkgo-e2e/e2e/backup-restore_test.go
@@ -85,8 +85,12 @@ var _ = Describe("E2E - Install Kubewarden", Label("install-kubewarden"), func()
 			InstallKubewarden(k)
 		})
 		By("Deploying custom policy-server", func() {
+			// Get current version of policy-server
+			policyServerImage, _ := kubectl.Run("get", "deployment", "policy-server-default",
+				"-n", "kubewarden", "-o", "jsonpath={.spec.template.spec.containers[0].image}")
+			Expect(policyServerImage).To(Not(BeEmpty()))
+
 			// Set the policy server name and image in the policy-server.yaml file
-			policyServerImage := "ghcr.io/kubewarden/policy-server:v1.27.0"
 			err := tools.Sed("%POLICY_SERVER_NAME%", "production", policyServerYaml)
 			Expect(err).To(Not(HaveOccurred()))
 			err = tools.Sed("%POLICY_SERVER_IMAGE%", policyServerImage, policyServerYaml)


### PR DESCRIPTION
## Description

Remove this dirty hard-coded thing 😅 
I spotted this issue thank to the sigstore issue:
```
# thread 'main' panicked at src/config/verification.rs:229:18:
# no rekor keys found inside of TUF repository: TufMetadataError("Did not find exactly 1 active Rekor key")
# note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Verification run
https://github.com/kubewarden/helm-charts/actions/runs/18497349321 ✅ 
