### PR TITLE
Registry pull-through cache for dockerhub

### DIFF
--- a/config/k3d-config-cache.yaml
+++ b/config/k3d-config-cache.yaml
@@ -1,0 +1,23 @@
+# Configure pull-through cache for Docker Hub (default)
+# https://k3d.io/v5.8.3/usage/registries/#creating-a-registry-proxy-pull-through-registry
+
+apiVersion: k3d.io/v1alpha5
+kind: Simple
+
+registries:
+  create:
+    name: k3d-docker.io
+    proxy:
+      remoteURL: https://registry-1.docker.io
+      # Authenticate to Docker Hub (increase rate limit to 200 pulls per hour)
+      username: "$DOCKERHUB_USERNAME"
+      password: "$DOCKERHUB_PASSWORD"
+    volumes:
+      - /var/cache/registry/docker-io:/var/lib/registry
+
+  config: |
+    mirrors:
+      # Pull-through cache for Docker Hub
+      "docker.io":
+        endpoint:
+          - http://k3d-docker.io:5000

--- a/scripts/cluster_k3d.sh
+++ b/scripts/cluster_k3d.sh
@@ -35,13 +35,11 @@ if [ "${1:-}" == 'create' ]; then
     fi
 
     # /dev/mapper: https://k3d.io/v5.7.4/faq/faq/#issues-with-btrfs
-    # registry-config: https://k3d.io/v5.8.3/faq/faq/#dockerhub-pull-rate-limit
     k3d cluster create "$CLUSTER_NAME" --wait \
+        --config config/k3d-config-cache.yaml \
         --image "rancher/k3s:$K3S" \
         -s "$MASTER_COUNT" -a "$WORKER_COUNT" \
-        --registry-create "k3d-$CLUSTER_NAME-registry" \
-        --registry-config <(echo "${K3D_REGISTRY_CONFIG:-}") \
-        -v /dev/mapper:/dev/mapper@all \
+        -v "/dev/mapper:/dev/mapper@all:*" \
         ${MTLS:+--k3s-arg '--kube-apiserver-arg=admission-control-config-file=/etc/mtls/admission.yaml@server:*'} \
         ${MTLS:+--volume "$MTLS_DIR:/etc/mtls@server:*"} \
         "${@:2}"


### PR DESCRIPTION
Currently tests create `k3d-$CLUSTER_NAME-registry` for every cluster, but we don't use it.

This change will create registry as pull-through cache for docker.io instead.

PR also removes option to set registry config by `K3D_REGISTRY_CONFIG`, which was used to authenticate to dockerhub.
Registry cache itself should be enough to avoid rate limits, but change also allows to set `DOCKERHUB_USERNAME` and `DOCKERHUB_PASSWORD` to login.
Github action secrets have to be updated to login.

Pull-through cache will be created automatically for every cluster.