### PR TITLE
Include only kubewarden charts in version map

### DIFF
--- a/scripts/helmer.sh
+++ b/scripts/helmer.sh
@@ -108,7 +108,7 @@ make_version_map() {
     if [ "$VERSION" != local ]; then
         # Do single helm search query to speed up the process
         helm repo update "$REPO_NAME" --fail-on-repo-update-fail >/dev/null
-        helm search repo --fail-on-no-result "$REPO_NAME/" --versions --devel -o json \
+        helm search repo --fail-on-no-result "$REPO_NAME/kubewarden-" --versions --devel -o json \
             | jq -ec --arg v "$VERSION" '
                 def remap(items): items | unique_by(.name) | map({(.name): .version, app_version: .app_version}) | add;
                 unique_by(.name) as $latest |


### PR DESCRIPTION
## Description

Releasing sbomscanner with kubewarden charts breaks version mapping (`app: 0.7.1`).

```bash
# Current issue
~ VERSION=next DRY=1 ./scripts/helmer.sh versions
Version map: (app:v0.7.1 crds:1.21.0 controller:5.7.0 defaults:3.7.2)

# Fixed version
~ VERSION=next DRY=1 ./scripts/helmer.sh versions
Version map: (app:v1.29.0 crds:1.21.0 controller:5.7.0 defaults:3.7.2)
```
