### PR TITLE
fix(policy): wait for policy-server rollout after every helmer set

### DIFF
--- a/tests/policy.bats
+++ b/tests/policy.bats
@@ -124,15 +124,18 @@ scaffold() {
         with(.spec.rules[0]; .apiGroups=[""] | .apiVersions=["v1"] | .resources=["pods"]) |
         .spec.settings.denied_labels=["denyap"] |
         .metadata.namespace = env(NAMESPACE)' | kubectl apply -f -
+    wait_policies
 
     # Both policies are allowed in controller ns
     helmer set kubewarden-controller --set alwaysAcceptAdmissionReviewsOnDeploymentsNamespace=false
+    wait_policies
     run ! kuberun -l denycap=1
     run ! kuberun -n $NAMESPACE -l denycap=1
     run ! kuberun -n $NAMESPACE -l denyap=1
 
     # Policies are not allowed in controller ns
     helmer set kubewarden-controller --set alwaysAcceptAdmissionReviewsOnDeploymentsNamespace=true
+    wait_policies
     kuberun -n $NAMESPACE -l denyap=1,denycap=1
 
     # Clean up


### PR DESCRIPTION
## Description

Every `helmer set` against kubewarden-controller or kubewarden-defaults in this file reconciles into a policy-server-default deployment rollout. Tests that run admission checks, apply_policy, or kubectl run right after the helmer set race the rollout. The new pod is still ContainerCreating while the assertion runs, so the policy looks like it is not enforced.

Add `wait_policyserver default` after each of the four helmer set call sites to drain the rollout before continuing. The existing `wait_policies` calls then handle per-policy readiness.


Found during working on https://github.com/kubewarden/adm-controller/issues/1740
