### PR TITLE
test(basic): assert policies stay in Scheduled status after PolicyServer delete

### DIFF
--- a/helpers/helpers.sh
+++ b/helpers/helpers.sh
@@ -113,6 +113,15 @@ function delete_policy {
     kubectl delete --wait -f "$(policypath "$1")" "${@:2}"
 }
 
+# apply_policy_for_ps <ps-name> <policy-file>
+# Deploy a policy targeting a specific PolicyServer.
+function apply_policy_for_ps {
+    local ps_name="$1"
+    local ps_file="$2"
+
+    ps="$ps_name" yq '.spec.policyServer = env(ps)' "$(policypath "$ps_file")" | apply_policy
+}
+
 # wait_policies [condition] - at least one policy must exist
 function wait_policies {
     local resources="admissionpolicies,clusteradmissionpolicies"

--- a/tests/basic-tests.bats
+++ b/tests/basic-tests.bats
@@ -120,3 +120,39 @@ helm_get() {
 
     kubectl delete ps e2e-tests
 }
+
+@test "$(tfile) Deleting a PolicyServer keeps its policies in Scheduled status" {
+    if helm get values -n $NAMESPACE kubewarden-controller -o json | jq -e '.image.tag != "latest"'; then
+        skip "Trigger only on adm-controller until 1.36.0 release"
+    fi
+    
+    local ps=e2e-scheduled
+    local policy=safe-labels-for-pods
+
+    create_policyserver $ps
+    apply_policy_for_ps $ps safe-labels-pods-policy.yaml
+
+    # Sanity: the policy is active before deletion
+    [ "$(kubectl get cap $policy -o jsonpath='{.status.policyStatus}')" = "active" ]
+
+    # Capture the validating webhook configuration created for this policy
+    local webhook
+    webhook=$(kubectl get validatingwebhookconfigurations -o name | grep "$policy\$")
+    [ -n "$webhook" ]
+
+    # Delete the PolicyServer (--wait blocks only on the PolicyServer itself)
+    kubectl delete ps $ps --wait
+
+    # The policy resource is preserved
+    kubectl get cap $policy
+
+    # The policy transitions to Scheduled
+    kubectl wait --for=jsonpath='{.status.policyStatus}=scheduled' cap $policy --timeout=2m
+
+    # The validating webhook configuration was removed
+    run kubectl get $webhook
+    assert_failure
+
+    # Cleanup
+    kubectl delete cap $policy --wait
+}


### PR DESCRIPTION
## Description

Following the breaking change in adm-controller PR #1724, deleting a PolicyServer no longer cascade-deletes its policies. Add a test that creates a second PolicyServer with an attached ClusterAdmissionPolicy, deletes the PolicyServer, and asserts that the policy resource is preserved, status.policyStatus transitions to "scheduled", and the validating webhook configuration is removed. 

Add the apply_policy_for_ps helper to helpers.sh so the test can target the second PolicyServer.

Fix https://github.com/kubewarden/adm-controller/issues/1740
