### PR TITLE
Print logs on terminal only in CI

### DIFF
--- a/helpers/helpers.sh
+++ b/helpers/helpers.sh
@@ -39,12 +39,18 @@ teardown_helper() {
     # Conditional skip (based on .skip file & KEEP var)
     if [[ -f "$BATS_RUN_TMPDIR/.skip" ]]; then
         if [[ "$BATS_TEST_FILENAME" == "$(< "$BATS_RUN_TMPDIR/.skip")" ]]; then
-            # Collect logs before teardown
-            kubectl get all -n $NAMESPACE >&3
-            kubectl get events -n $NAMESPACE >&3
-            kubectl logs -n $NAMESPACE -l app.kubernetes.io/component=controller --all-containers >&3
-            kubectl logs -n $NAMESPACE -l app.kubernetes.io/component=policy-server --all-containers >&3
-            kubectl describe pods -n $NAMESPACE >&3
+            # Print logs in CI before teardown
+            if [ -v CI ]; then
+                warn Get all -n $NAMESPACE >&3
+                kubectl get all -n $NAMESPACE >&3
+
+                warn Get events -n $NAMESPACE >&3
+                kubectl get events -n $NAMESPACE >&3
+
+                warn Get logs -n $NAMESPACE >&3
+                kubectl logs -n $NAMESPACE -l app.kubernetes.io/component=controller --all-containers >&3
+                kubectl logs -n $NAMESPACE -l app.kubernetes.io/component=policy-server --all-containers >&3
+            fi
             [[ -n "${KEEP:-}" ]] && skip "skip teardown of failed test"
         else
             skip "skip teardown of remaining tests"

--- a/tests/basic-tests.bats
+++ b/tests/basic-tests.bats
@@ -125,7 +125,7 @@ helm_get() {
     if helm get values -n $NAMESPACE kubewarden-controller -o json | jq -e '.image.tag != "latest"'; then
         skip "Trigger only on adm-controller until 1.36.0 release"
     fi
-    
+
     local ps=e2e-scheduled
     local policy=safe-labels-for-pods
 


### PR DESCRIPTION
## Description

Print logs only when running in CI (github). When running locally we have `KEEP=1` flag to debug.
