### PR TITLE
Fix kubectl wait & update k3s

### DIFF
--- a/helpers/kubelib.sh
+++ b/helpers/kubelib.sh
@@ -63,7 +63,11 @@ function wait_nodes() {
 }
 
 # Wait for Ready condition by default, could be overridden with --for=condition=...
-function wait_for    () { kubectl wait --timeout=5m --for=condition=Ready "$@"; }
+function wait_for () {
+    local for_flag="--for=condition=Ready"
+    [[ " $* " == *" --for"* ]] && for_flag=""
+    kubectl wait --timeout=5m $for_flag "$@"
+}
 # Wait for terminating pods after rollout
 function wait_rollout() { kubectl rollout status --timeout=5m -n "$NAMESPACE" "$@"; wait_pods; }
 

--- a/scripts/cluster_k3d.sh
+++ b/scripts/cluster_k3d.sh
@@ -3,7 +3,7 @@ set -aeEuo pipefail
 trap 'echo "Error on ${BASH_SOURCE/$PWD/.}:${LINENO} $(sed -n "${LINENO} s/^\s*//p" $PWD/${BASH_SOURCE/$PWD})"' ERR
 
 # Optional variables
-K3S=${K3S:-$(k3d version -o json | jq -r '.k3s')}
+K3S=${K3S:-$(kubectl version --client -o json | jq -r '.clientVersion | .major+"."+.minor')}
 CLUSTER_NAME=${CLUSTER_NAME:-k3s-default}
 MASTER_COUNT=${MASTER_COUNT:-1}
 WORKER_COUNT=${WORKER_COUNT:-0}


### PR DESCRIPTION
## Description

- We use k3s default from k3d, which is 1.31. Get default version from kubectl instead.
- Update kubectl wait to replace default value if there is `--for` in parameter

Before `kubectl wait` accepted only one `--for=condition...`. If you provided more --for only last one is considered.
In kubectl 1.36.1 all `--for` conditions are AND'ed together.