### PR TITLE
chore: filter out host network tests by default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,9 @@ $(foreach var,$(VARIABLES),$(if $(call is_falsy,$(var)),$(eval override $(var)=)
 
 # Generate target for every test file
 TESTFILES := $(notdir $(wildcard $(TESTS_DIR)/*.bats))
-# Filter out audit-scanner-installation because it reinstalls kubewarden
-FILTERED := $(filter-out audit-scanner-installation.bats, $(TESTFILES))
+# Filter out audit-scanner-installation because it reinstalls kubewarden. And,
+# host-network-tests because they are slow
+FILTERED := $(filter-out audit-scanner-installation.bats host-network-tests.bats, $(TESTFILES))
 # Filter out mutual-tls if MTLS is not set
 ifeq ($(MTLS),)
     FILTERED := $(filter-out mutual-tls.bats, $(FILTERED))


### PR DESCRIPTION
## Description

Currently, host network test are quite slow. Therefore, to avoid too much waiting in the PRs CI, adds they in the list of test to be run only when necessary.
