### PR TITLE
Fix retry helper for k8s 1.36

### DIFF
--- a/helpers/kubelib.sh
+++ b/helpers/kubelib.sh
@@ -30,9 +30,9 @@ function retry() {
     local i status
 
     for ((i=1; i<=tries; i++)); do
-        timeout "$delay" bash -c "$cmd" && break || status=$?
+        timeout "$delay" bash -c "$cmd" </dev/null && break || status=$?
         if [[ $i -lt $tries ]]; then
-            echo "RETRY #$i: $cmd"
+            echo "RETRY #$i [$status]: $cmd"
             [[ $status -ne 124 ]] && sleep $delay
         else
             echo "Godot ($status): $cmd"; false
@@ -148,10 +148,10 @@ function kuberun {
     # No command (-- is missing): use -- true as default
     [[ " $* " != *" -- "* ]] && set -- "$@" -- true
     # Set command defaults
-    [[ "$*" =~ "-- wget" ]] && set -- "${@/-- wget/-- wget --quiet --no-check-certificates}"
-    [[ "$*" =~ "-- curl" ]] && set -- "${@/-- curl/-- curl -k --no-progress-meter}"
+    [[ "$*" =~ "-- wget" ]] && set -- -- wget --quiet --no-check-certificate "${@:3}"
+    [[ "$*" =~ "-- curl" ]] && set -- -- curl -k --no-progress-meter "${@:3}"
 
-    kubectl run "pod-$(date +%s)" --image=busybox --restart=Never --rm -it -q --command "$@"
+    kubectl run "pod-$(date +%s)" --image=busybox --restart=Never --rm -i -q --command "$@"
 }
 export -f kuberun
 


### PR DESCRIPTION
## Description

Since k8s 1.36 running command in for of `timeout N bash -c "kubectl run --rm ..."` creates pod, but does not delete it.
Pod is left in Completed state and command is killed by timeout with exit code 124.

K8s 1.35 works fine, also github runner seems to be unaffected because of it's specific terminal.
Problem appeared during local runs.

```bash
# this command passes:
kubectl run pod-$(date +%s) --image=busybox --restart=Never --rm -it -q --command -- true

# this command fails:
retry "kubectl run pod-$(date +%s) --image=busybox --restart=Never --rm -it -q --command -- true"
```

Without `</dev/null` child process inherits stdin.


I also fixed default parameters for wget & curl, original fix was not used.
`${@/-- wget/..` tries to match 2 elements in one position. Array structure is `[0]: --`, `[1]: wget`.