### PR TITLE
Adapt airgap test to single helm chart

### DIFF
--- a/tests/ginkgo-e2e/e2e/airgap_test.go
+++ b/tests/ginkgo-e2e/e2e/airgap_test.go
@@ -154,57 +154,25 @@ var _ = Describe("E2E - Deploy K3S/Rancher in airgap environment", Label("airgap
 			Expect(err).To(Not(HaveOccurred()))
 		})
 
-		By("Installing Kubewarden crds", func() {
-			// Set flags for Kubewarden-crds installation
+		By("Installing admission controller", func() {
+			// Set flags for admission controller installation
 			flags := []string{
-				"upgrade", "--install", "kubewarden-crds", "oci://" + repoServer + "/hauler/kubewarden-crds",
+				"upgrade", "--install", "admission-controller", "oci://" + repoServer + "/hauler/admission-controller",
 				"--namespace", "kubewarden",
 				"--create-namespace",
 				"--plain-http",
-				"--devel",
-			}
-
-			RunHelmCmdWithRetry(flags...)
-		})
-
-		By("Installing Kubewarden controller", func() {
-			// Set flags for Kubewarden controller installation
-			flags := []string{
-				"upgrade", "--install", "kubewarden-controller", "oci://" + repoServer + "/hauler/kubewarden-controller",
-				"--namespace", "kubewarden",
-				"--plain-http",
 				"--set", "global.cattle.systemDefaultRegistry=" + repoServer,
-				"--set", "image.tag=" + kubewardenControllerVersion,
+				"--set", "image.tag=" + admControllerVersion,
 				"--set", "auditScanner.image.tag=" + auditScannerVersion,
-				"--wait", "--wait-for-jobs",
-				"--devel",
-			}
-
-			RunHelmCmdWithRetry(flags...)
-
-			// Wait for all pods to be started
-			checkList := [][]string{
-				{"kubewarden", "app.kubernetes.io/name=kubewarden-controller"},
-			}
-			err := rancher.CheckPod(k, checkList)
-			Expect(err).To(Not(HaveOccurred()))
-		})
-
-		By("Installing Kubewarden defaults", func() {
-			// Set flags for Kubewarden defaults installation
-			flags := []string{
-				"upgrade", "--install", "kubewarden-defaults", "oci://" + repoServer + "/hauler/kubewarden-defaults",
-				"--namespace", "kubewarden",
-				"--plain-http",
-				"--set", "global.cattle.systemDefaultRegistry=" + repoServer,
+				"--set", "policyServer.image.tag=" + policyServerVersion,
 				"--set", "policyServer.insecureSources[0]=" + rancherManager,
 				"--set", "policyServer.insecureSources[1]=" + repoServer,
-				"--set", "policyServer.image.tag=" + policyServerVersion,
 				"--set", "recommendedPolicies.enabled=true",
 				"--set", "recommendedPolicies.defaultPoliciesRegistry=" + repoServer,
 				"--wait", "--wait-for-jobs",
 				"--devel",
 			}
+
 			// Add policy versions only if not upgrade test
 			if testType != "upgrade" {
 				flags = append(flags,
@@ -216,13 +184,18 @@ var _ = Describe("E2E - Deploy K3S/Rancher in airgap environment", Label("airgap
 					"--set", "recommendedPolicies.capabilitiesPolicy.module.tag="+capabilitiesPolicyVersion,
 				)
 			}
+
 			RunHelmCmdWithRetry(flags...)
 
-			// Wait for pod to be started
-			err := rancher.CheckPod(k, [][]string{{"kubewarden", "app.kubernetes.io/name=policy-server"}})
+			// Wait for all pods to be started
+			checkList := [][]string{
+				{"kubewarden", "app.kubernetes.io/name=admission-controller"},
+				{"kubewarden", "app.kubernetes.io/component=policy-server"},
+			}
+			err := rancher.CheckPod(k, checkList)
 			Expect(err).To(Not(HaveOccurred()))
-
 		})
+
 		// TODO: check all policies
 		By("Checking that one policy is in active state", func() {
 			Eventually(func() string {

--- a/tests/ginkgo-e2e/e2e/airgap_upgrade_test.go
+++ b/tests/ginkgo-e2e/e2e/airgap_upgrade_test.go
@@ -87,52 +87,18 @@ var _ = Describe("E2E - Upgrade Kubewarden in airgap environment", Label("airgap
 			Expect(err).To(Not(HaveOccurred()), string(out))
 		})
 
-		By("Upgrading Kubewarden crds", func() {
-			// Set flags for Kubewarden-crds installation
+		By("Upgrading admission controller", func() {
+			// Set flags for admission controller installation
 			flags := []string{
-				"upgrade", "kubewarden-crds", "oci://" + repoServer + "/hauler/kubewarden-crds",
-				"--namespace", "kubewarden",
-				"--create-namespace",
-				"--plain-http",
-				"--devel",
-			}
-
-			RunHelmCmdWithRetry(flags...)
-		})
-
-		By("Upgrading Kubewarden controller", func() {
-			// Set flags for Kubewarden controller installation
-			flags := []string{
-				"upgrade", "kubewarden-controller", "oci://" + repoServer + "/hauler/kubewarden-controller",
+				"upgrade", "admission-controller", "oci://" + repoServer + "/hauler/admission-controller",
 				"--namespace", "kubewarden",
 				"--plain-http",
 				"--set", "global.cattle.systemDefaultRegistry=" + repoServer,
-				"--set", "image.tag=" + kubewardenControllerVersion,
+				"--set", "image.tag=" + admControllerVersion,
 				"--set", "auditScanner.image.tag=" + auditScannerVersion,
-				"--wait", "--wait-for-jobs",
-				"--devel",
-			}
-
-			RunHelmCmdWithRetry(flags...)
-
-			// Wait for all pods to be started
-			checkList := [][]string{
-				{"kubewarden", "app.kubernetes.io/name=kubewarden-controller"},
-			}
-			err := rancher.CheckPod(k, checkList)
-			Expect(err).To(Not(HaveOccurred()))
-		})
-
-		By("Upgrading Kubewarden defaults", func() {
-			// Set flags for Kubewarden defaults installation
-			flags := []string{
-				"upgrade", "kubewarden-defaults", "oci://" + repoServer + "/hauler/kubewarden-defaults",
-				"--namespace", "kubewarden",
-				"--plain-http",
-				"--set", "global.cattle.systemDefaultRegistry=" + repoServer,
+				"--set", "policyServer.image.tag=" + policyServerVersion,
 				"--set", "policyServer.insecureSources[0]=" + rancherManager,
 				"--set", "policyServer.insecureSources[1]=" + repoServer,
-				"--set", "policyServer.image.tag=" + policyServerVersion,
 				"--set", "recommendedPolicies.enabled=true",
 				"--set", "recommendedPolicies.defaultPoliciesRegistry=" + repoServer,
 				"--set", "recommendedPolicies.allowPrivilegeEscalationPolicy.module.tag=" + allowPrivilegeEscalationPolicyVersion,
@@ -144,13 +110,18 @@ var _ = Describe("E2E - Upgrade Kubewarden in airgap environment", Label("airgap
 				"--wait", "--wait-for-jobs",
 				"--devel",
 			}
+
 			RunHelmCmdWithRetry(flags...)
 
-			// Wait for pod to be started
-			err := rancher.CheckPod(k, [][]string{{"kubewarden", "app.kubernetes.io/name=policy-server"}})
+			// Wait for all pods to be started
+			checkList := [][]string{
+				{"kubewarden", "app.kubernetes.io/name=admission-controller"},
+				{"kubewarden", "app.kubernetes.io/component=policy-server"},
+			}
+			err := rancher.CheckPod(k, checkList)
 			Expect(err).To(Not(HaveOccurred()))
-
 		})
+
 		// TODO: check all policies
 		By("Checking that one policy is in active state", func() {
 			Eventually(func() string {

--- a/tests/ginkgo-e2e/e2e/suite_test.go
+++ b/tests/ginkgo-e2e/e2e/suite_test.go
@@ -51,7 +51,7 @@ var (
 	capabilitiesPolicyVersion             string
 	hostNamespacePolicyVersion            string
 	hostPathsPolicyVersion                string
-	kubewardenControllerVersion           string
+	admControllerVersion                  string
 	k3sVersion                            string
 	podPrivilegedPolicyVersion            string
 	policyServerVersion                   string
@@ -291,7 +291,7 @@ var _ = BeforeSuite(func() {
 	podPrivilegedPolicyVersion = os.Getenv("POD_PRIVILEGED_PSP_VERSION")
 	userGroupPolicyVersion = os.Getenv("USER_GROUP_PSP_VERSION")
 	backupRestoreVersion = os.Getenv("BACKUP_RESTORE_VERSION")
-	kubewardenControllerVersion = os.Getenv("KUBEWARDEN_CONTROLLER_VERSION")
+	admControllerVersion = os.Getenv("ADM_CONTROLLER_VERSION")
 	policyServerVersion = os.Getenv("POLICY_SERVER_VERSION")
 	k3sVersion = os.Getenv("INSTALL_K3S_VERSION")
 	netDefaultFileName = "../assets/net-default-airgap.xml"

--- a/tests/ginkgo-e2e/scripts/deploy-chartmuseum
+++ b/tests/ginkgo-e2e/scripts/deploy-chartmuseum
@@ -33,12 +33,10 @@ helm repo add chartmuseum http://localhost:8080
 
 # Push helm charts to local repo
 cd ../../../charts
-helm cm-push kubewarden-crds chartmuseum
-helm cm-push kubewarden-controller chartmuseum
-helm cm-push kubewarden-defaults chartmuseum
+helm cm-push adm-controller chartmuseum
 
 # Update the hauler manifest with the new repo
-for chart in kubewarden-crds kubewarden-controller kubewarden-defaults; do
+for chart in admission-controller; do
   yq -i '
     (.spec.charts[] | select(.name == "'"$chart"'").repoURL) = "'"$REPO_URL"'"
   ' $HAULER_MANIFEST


### PR DESCRIPTION
## Description

Provide changes to use single helm chart in airgap test as well as the renaming from kubewarden-controller to admission-controller

Fix #316 
