### PR TITLE
fix: run k3d with etcd

### DIFF
--- a/config/k3d-config-cache.yaml
+++ b/config/k3d-config-cache.yaml
@@ -13,6 +13,14 @@ kind: Simple
 #         nodeFilters:
 #           - all:*
 
+options:
+  k3s:
+    extraArgs:
+      # enable etcd to avoid read-after-write issues in the audit scanner tests
+      - arg: "--cluster-init"
+        nodeFilters:
+          - all:*
+
 registries:
   create:
     name: k3d-docker.io


### PR DESCRIPTION
## Description

Recently the audit scanner tests start to fail due some read-after-write issue during the DeleteAllOf call. This happens because k3s uses SQLite as database and propagate the changes using watches. The process can take some time and to the time that delete operation is performed the data is out of date. Therefore, it operates on data missing the patch call perform previously. This commit fixes that by configuring the k3s to run with etcd as database.

Fix https://github.com/kubewarden/adm-controller/issues/1838

> [!IMPORTANT]
> This is fix/workaround for the tests only. The audit scanner still can face the same issue reported at https://github.com/kubewarden/adm-controller/issues/1838 if it run in a cluster with similar scenario. Therefore, the [PR](https://github.com/kubewarden/adm-controller/pull/1859) still should be considered and reviewed
