### PR TITLE
fix: run k3d with etcd

### DIFF
--- a/config/k3d-config-cache.yaml
+++ b/config/k3d-config-cache.yaml
@@ -16,7 +16,7 @@ kind: Simple
 options:
   k3s:
     extraArgs:
-      # enable etcd to avoid read-after-write issues in the audit scanner tests
+      # Enable etcd to avoid read-after-write issues with sqlite (default)
       - arg: "--cluster-init"
         nodeFilters:
           - server:0

--- a/config/k3d-config-cache.yaml
+++ b/config/k3d-config-cache.yaml
@@ -13,6 +13,14 @@ kind: Simple
 #         nodeFilters:
 #           - all:*
 
+options:
+  k3s:
+    extraArgs:
+      # enable etcd to avoid read-after-write issues in the audit scanner tests
+      - arg: "--cluster-init"
+        nodeFilters:
+          - all:*
+
 registries:
   create:
     name: k3d-docker.io

--- a/config/k3d-config-cache.yaml
+++ b/config/k3d-config-cache.yaml
@@ -19,7 +19,7 @@ options:
       # enable etcd to avoid read-after-write issues in the audit scanner tests
       - arg: "--cluster-init"
         nodeFilters:
-          - all:*
+          - server:0
 
 registries:
   create:


### PR DESCRIPTION
## Description

Recently the audit scanner tests start to fail due some read-after-write issue during the DeleteAllOf call. This happens because k3s uses SQLite as database and propagate the changes using watches. The process can take some time and to the time that delete operation is performed the data is out of date. Therefore, it operates on data missing the patch call perform previously. This was [fixed](https://github.com/kubewarden/adm-controller/pull/1859) in the audit scanner code.

However, there is another face of the same issue. We have a [test](https://github.com/kubewarden/kubewarden-end-to-end-tests/blob/d39bb86e8296b8ebaf79f6f443a08e353a699507/tests/audit-scanner-installation.bats#L43-L63) where is verified if uninstall CRDs are gone. However, k3d is still reporting that the CRDs are present (one of the two deleted):

```
2026-07-13T16:34:24.8739474Z # helm_up admission-controller ../charts/admission-controller --version 6.0.0-alpha --set image.tag=latest --set auditScanner.image.tag=latest --set policyServer.image.tag=latest --set installOpenReportsCRDs=False
2026-07-13T16:34:24.8753958Z # Release "admission-controller" does not exist. Installing it now.
2026-07-13T16:34:24.8755160Z # NAME: admission-controller
2026-07-13T16:34:24.8755760Z # LAST DEPLOYED: Mon Jul 13 16:33:43 2026
2026-07-13T16:34:24.8756381Z # NAMESPACE: kubewarden
2026-07-13T16:34:24.8756900Z # STATUS: deployed
2026-07-13T16:34:24.8757381Z # REVISION: 1
2026-07-13T16:34:24.8757851Z # TEST SUITE: None
2026-07-13T16:34:24.8758587Z # Error from server (NotFound): deployments.apps "policy-server-default" not found
2026-07-13T16:34:24.8759601Z # RETRY #1 [1]: kubectl get -n kubewarden deployment/policy-server-default
2026-07-13T16:34:24.8760436Z # NAME                    READY   UP-TO-DATE   AVAILABLE   AGE
2026-07-13T16:34:24.8761492Z # policy-server-default   1/1     1            1           7s
2026-07-13T16:34:24.8762330Z # deployment "policy-server-default" successfully rolled out
2026-07-13T16:34:24.8763024Z # true
2026-07-13T16:34:24.8763491Z # true
2026-07-13T16:34:24.8764031Z # Uninstall: admission-controller --ignore-not-found
2026-07-13T16:34:24.8764799Z # These resources were kept due to the resource policy:
2026-07-13T16:34:24.8765774Z # [CustomResourceDefinition] clusteradmissionpolicygroups.policies.kubewarden.io
2026-07-13T16:34:24.8766845Z # [CustomResourceDefinition] policyservers.policies.kubewarden.io
2026-07-13T16:34:24.8767813Z # [CustomResourceDefinition] admissionpolicies.policies.kubewarden.io
2026-07-13T16:34:24.8768883Z # [CustomResourceDefinition] admissionpolicygroups.policies.kubewarden.io
2026-07-13T16:34:24.8769978Z # [CustomResourceDefinition] clusteradmissionpolicies.policies.kubewarden.io
2026-07-13T16:34:24.8770968Z #
2026-07-13T16:34:24.8771466Z # release "admission-controller" uninstalled
2026-07-13T16:34:24.8772420Z # customresourcedefinition.apiextensions.k8s.io "clusterreports.openreports.io" deleted
2026-07-13T16:34:24.8773630Z # customresourcedefinition.apiextensions.k8s.io "reports.openreports.io" deleted
```

Note that `OpenReports` CRDs are removed.  But the `kubectl get crds` is still returning one of them:

```
# > reports                             reps         openreports.io/v1alpha1           true    Report
```

While we have this instability on the k3d behavior, I'm enabling the etcd3 in our test to allow us to have a more reliable feedback from our tests during [release process](https://github.com/kubewarden/adm-controller/issues/1892).

The above log came from the first attempt to run the end-to-end test [here](https://github.com/kubewarden/adm-controller/actions/runs/29262957451/attempts/1)

Related to https://github.com/k3s-io/kine/issues/704
