### PR TITLE
feat: Add uninstall-tests testcase that doubles as an idempotent cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,13 +49,18 @@ $(foreach var,$(VARIABLES),$(if $(call is_falsy,$(var)),$(eval override $(var)=)
 
 # Generate target for every test file
 TESTFILES := $(notdir $(wildcard $(TESTS_DIR)/*.bats))
-# Filter out audit-scanner-installation because it reinstalls kubewarden. And,
-# host-network-tests because they are slow
-FILTERED := $(filter-out audit-scanner-installation.bats host-network-tests.bats, $(TESTFILES))
+# Filter out:
+# - audit-scanner-installation because it reinstalls kubewarden
+# - host-network-tests because they are slow
+# - uninstall-tests is re-appended below so it always runs last
+FILTERED := $(filter-out audit-scanner-installation.bats uninstall-tests.bats host-network-tests.bats, $(TESTFILES))
 # Filter out mutual-tls if MTLS is not set
 ifeq ($(MTLS),)
     FILTERED := $(filter-out mutual-tls.bats, $(FILTERED))
 endif
+# Run uninstall-tests last: it uninstalls kubewarden and doubles as the suite
+# cleanup, failing if any test left resources behind
+FILTERED += uninstall-tests.bats
 # Remove requested .bats targets from FILTERED to avoid duplicates
 FILTERED := $(filter-out $(filter %.bats,$(MAKECMDGOALS)), $(FILTERED))
 
@@ -66,6 +71,9 @@ BATS_SELECTED := $(strip $(foreach goal,$(MAKECMDGOALS),\
     $(if $(filter %.bats,$(goal)),$(goal)))))
 # If no goals specified, use filtered tests
 BATS_SELECTED := $(or $(BATS_SELECTED),$(FILTERED))
+# uninstall-tests removes kubewarden (incl. CRDs): whenever selected, always
+# run it last, regardless of the goal order on the command line
+BATS_SELECTED := $(filter-out uninstall-tests.bats,$(BATS_SELECTED)) $(filter uninstall-tests.bats,$(BATS_SELECTED))
 
 # ==================================================================================================
 # Use .run-bats to call bats only once per execution. Required to abort tests on failure

--- a/Makefile
+++ b/Makefile
@@ -52,15 +52,11 @@ TESTFILES := $(notdir $(wildcard $(TESTS_DIR)/*.bats))
 # Filter out:
 # - audit-scanner-installation because it reinstalls kubewarden
 # - host-network-tests because they are slow
-# - uninstall-tests is re-appended below so it always runs last
-FILTERED := $(filter-out audit-scanner-installation.bats uninstall-tests.bats host-network-tests.bats, $(TESTFILES))
+FILTERED := $(filter-out audit-scanner-installation.bats host-network-tests.bats, $(TESTFILES))
 # Filter out mutual-tls if MTLS is not set
 ifeq ($(MTLS),)
     FILTERED := $(filter-out mutual-tls.bats, $(FILTERED))
 endif
-# Run uninstall-tests last: it uninstalls kubewarden and doubles as the suite
-# cleanup, failing if any test left resources behind
-FILTERED += uninstall-tests.bats
 # Remove requested .bats targets from FILTERED to avoid duplicates
 FILTERED := $(filter-out $(filter %.bats,$(MAKECMDGOALS)), $(FILTERED))
 
@@ -71,9 +67,6 @@ BATS_SELECTED := $(strip $(foreach goal,$(MAKECMDGOALS),\
     $(if $(filter %.bats,$(goal)),$(goal)))))
 # If no goals specified, use filtered tests
 BATS_SELECTED := $(or $(BATS_SELECTED),$(FILTERED))
-# uninstall-tests removes kubewarden (incl. CRDs): whenever selected, always
-# run it last, regardless of the goal order on the command line
-BATS_SELECTED := $(filter-out uninstall-tests.bats,$(BATS_SELECTED)) $(filter uninstall-tests.bats,$(BATS_SELECTED))
 
 # ==================================================================================================
 # Use .run-bats to call bats only once per execution. Required to abort tests on failure

--- a/tests/uninstall-tests.bats
+++ b/tests/uninstall-tests.bats
@@ -19,6 +19,9 @@
 setup() {
     setup_helper
 }
+teardown_file() {
+    teardown_helper
+}
 
 TEST_FINALIZER=e2e.kubewarden.io/test-finalizer
 PS_NAME=e2e-uninstall
@@ -129,8 +132,8 @@ release_test_finalizer() {
     release_test_finalizer ps $PS_NAME
 
     # Without a running controller, plain kubectl delete must complete on its own
-    kubectl delete --ignore-not-found --timeout=30s cap $POLICY_NAME
-    kubectl delete --ignore-not-found --timeout=30s ps $PS_NAME
+    kubectl delete --timeout=30s cap $POLICY_NAME
+    kubectl delete --timeout=30s ps $PS_NAME
 }
 
 # kubewarden is uninstalled: skip the pods wait, it hangs on an empty namespace
@@ -169,4 +172,7 @@ release_test_finalizer() {
     # Nothing Kubewarden-related is left in the cluster
     run kubectl get crds -o name
     refute_output -p kubewarden.io
+
+    # Return to initial state
+    helmer reinstall
 }

--- a/tests/uninstall-tests.bats
+++ b/tests/uninstall-tests.bats
@@ -35,15 +35,9 @@ setup() {
 
     # Version check and pod wait only make sense while kubewarden is still
     # installed.
-    #
-    # Pre-delete hook controller cleanup was introduced in Kubewarden 1.37.
-    # Remember the skip-version decision, since later tests run after the
-    # uninstall and cannot check it anymore.
     if helm status -n "$NAMESPACE" admission-controller &>/dev/null; then
-        kw_version ">=1.37" || touch "$BATS_FILE_TMPDIR/.skip-version"
         wait_pods -n "$NAMESPACE"
     fi
-    [ ! -f "$BATS_FILE_TMPDIR/.skip-version" ] || skip "Requires admission-controller >= 1.37.0"
 }
 
 TEST_FINALIZER=e2e.kubewarden.io/test-finalizer

--- a/tests/uninstall-tests.bats
+++ b/tests/uninstall-tests.bats
@@ -2,8 +2,6 @@
 
 # Tests for the pre-delete-hook of the admission-controller uninstall
 # that runs the controller image in cleanup mode.
-# These tests also double as testsuite cleanup step, deleting CRs and CRDs at
-# the end.
 #
 # The uninstall must leave behind ONLY the Kubewarden CRDs and the
 # user-defined PolicyServer/policy CRs (with the Kubewarden finalizers
@@ -15,29 +13,11 @@
 # For that, we add a test Finalizer that simulates third-party tooling: the
 # cleanup must keep it in place and must not hang waiting on resources it does
 # not own (the deletion is issued and the cleanup moves on). The finalizer is
-# released again by the escape hatch testcase, and the final testcase fails if
-# ANY Kubewarden resource (other than the CRDs) is still around. This file thus
-# doubles as the suite cleanup: run it last, there is no separate teardown to
-# reinstall or to sweep leftovers, so incomplete cleanup cannot be masked.
-#
-# As a cleanup step, the testcase is idempotent: on a re-run against an already
-# uninstalled cluster the install-dependent tests skip, the escape hatch
-# no-ops, and the final leftover audit re-runs and enforces the clean state.
+# released again in a later testcase, and the final testcase fails if ANY
+# Kubewarden resource (other than the CRDs) is still around.
 
-# Waiting for pods with wait_pods only makes sense while Kubewarden is
-# installed (the first run of this testcase/cleanup). Subsequent runs would
-# hang until timeout.
-# Therefore, all tests are tagged `setup:--no-wait` which disables the generic
-# wait_pods in setup_helper(), and a replacement wait_pods is inside the
-# setup(), only run when there's an installed admission-controller.
 setup() {
     setup_helper
-
-    # Version check and pod wait only make sense while kubewarden is still
-    # installed.
-    if helm status -n "$NAMESPACE" admission-controller &>/dev/null; then
-        wait_pods -n "$NAMESPACE"
-    fi
 }
 
 TEST_FINALIZER=e2e.kubewarden.io/test-finalizer
@@ -45,10 +25,10 @@ PS_NAME=e2e-uninstall
 POLICY_NAME=safe-labels-for-pods
 
 # add_test_finalizer <kind> <name> [-n namespace]
-# Idempotent: does nothing if the finalizer is already set (the API server
-# rejects duplicate finalizers).
-# Also works when the resource has no finalizers array yet
-# (a JSON-patch "add /metadata/finalizers/-" would fail on those).
+# Idempotent: does nothing if the finalizer is set (the API server rejects
+# duplicate finalizers).
+# Uses a merge patch: a JSON-patch "add /metadata/finalizers/-" would fail
+# on resources without a finalizers array.
 add_test_finalizer() {
     local finalizers
     finalizers=$(kubectl get "$1" "$2" "${@:3}" -o json |
@@ -65,16 +45,8 @@ release_test_finalizer() {
     kubectl patch "$1" "$2" "${@:3}" --type=merge -p "{\"metadata\":{\"finalizers\":$finalizers}}"
 }
 
-# Skip tests if no installed kubewarden, so the whole file is idempotent and
-# converges on the final audit.
-skip_uninstalled() {
-    helm status -n "$NAMESPACE" admission-controller &>/dev/null || skip "kubewarden is not installed"
-}
-
-# bats test_tags=setup:--no-wait
 @test "$(tfile) Prepare user resources with test finalizers" {
     # test requires an installed kubewarden
-    skip_uninstalled
 
     # User-defined PolicyServer with a policy assigned to it
     create_policyserver $PS_NAME
@@ -96,11 +68,10 @@ skip_uninstalled() {
     add_test_finalizer configmap policy-server-$PS_NAME -n "$NAMESPACE"
 }
 
-# bats test_tags=setup:--no-wait
 @test "$(tfile) Uninstall runs the pre-delete hook cleanup" {
     # test requires an installed kubewarden
-    skip_uninstalled
 
+    # uninstall admission-controller
     helmer uninstall
 
     # The pre-delete Job is removed on success (hook-delete-policy: hook-succeeded)
@@ -147,10 +118,11 @@ skip_uninstalled() {
     kubectl wait --for=delete --timeout=60s pods -A -l app.kubernetes.io/part-of=kubewarden
 }
 
+# kubewarden is uninstalled: skip the pods wait, it hangs on an empty namespace
 # bats test_tags=setup:--no-wait
-@test "$(tfile) Escape hatch: resources are deletable once finalizers are released" {
+@test "$(tfile) Resources are deletable once finalizers are released" {
     # Releasing the test finalizer completes the ConfigMap deletion issued
-    # by the cleanup (already-gone means success, so this is re-run safe).
+    # by the cleanup
     release_test_finalizer configmap policy-server-$PS_NAME -n "$NAMESPACE"
     kubectl wait --for=delete --timeout=30s configmap policy-server-$PS_NAME -n "$NAMESPACE"
 
@@ -161,6 +133,7 @@ skip_uninstalled() {
     kubectl delete --ignore-not-found --timeout=30s ps $PS_NAME
 }
 
+# kubewarden is uninstalled: skip the pods wait, it hangs on an empty namespace
 # bats test_tags=setup:--no-wait
 @test "$(tfile) Nothing is left over after the uninstall" {
     # No Helm releases are left in the namespace
@@ -170,12 +143,8 @@ skip_uninstalled() {
     # No Kubewarden CRs are left: the previous testcases removed the
     # intentionally kept user CRs, and every other CR created by the test
     # suite or the charts must be gone.
-    # On a re-run the CRDs were already removed below, and no CRs can exist
-    # without them.
-    if kubectl get crds policyservers.policies.kubewarden.io &>/dev/null; then
-        run kubectl get ps,ap,cap,apg,capg -A
-        assert_output -p "No resources found"
-    fi
+    run kubectl get ps,ap,cap,apg,capg -A
+    assert_output -p "No resources found"
 
     # Nothing labeled as part of Kubewarden survived, namespaced...
     run kubectl get all,jobs,secrets,configmaps,pdb,serviceaccounts,leases -A -l app.kubernetes.io/part-of=kubewarden
@@ -189,13 +158,13 @@ skip_uninstalled() {
     run kubectl get all,secrets,configmaps,pdb -A -l app.kubernetes.io/component=policy-server
     assert_output -p "No resources found"
 
-    # Only the CRDs remain, kept on purpose for re-installation.
+    # Only the CRDs remain, kept on purpose for re-installation
     local crds
-    crds=$(kubectl get crds -o name | grep '\.kubewarden\.io$' || true)
-    [ -z "$crds" ] || [ "$(wc -l <<<"$crds")" -eq 5 ] # the 5 policies CRDs, nothing else
+    crds=$(kubectl get crds -o name | grep '\.kubewarden\.io$')
+    [ "$(wc -l <<<"$crds")" -eq 5 ] # the 5 kubewarden CRDs, nothing else
 
-    # Remove CRDs and CRs for a complete cleanup
-    [ -z "$crds" ] || kubectl delete --timeout=60s $crds
+    # Remove the CRDs for a complete cleanup
+    kubectl delete --timeout=60s $crds
 
     # Nothing Kubewarden-related is left in the cluster
     run kubectl get crds -o name

--- a/tests/uninstall-tests.bats
+++ b/tests/uninstall-tests.bats
@@ -24,14 +24,24 @@
 # uninstalled cluster the install-dependent tests skip, the escape hatch
 # no-ops, and the final leftover audit re-runs and enforces the clean state.
 
+# Waiting for pods with wait_pods only makes sense while Kubewarden is
+# installed (the first run of this testcase/cleanup). Subsequent runs would
+# hang until timeout.
+# Therefore, all tests are tagged `setup:--no-wait` which disables the generic
+# wait_pods in setup_helper(), and a replacement wait_pods is inside the
+# setup(), only run when there's an installed admission-controller.
 setup() {
     setup_helper
 
+    # Version check and pod wait only make sense while kubewarden is still
+    # installed.
+    #
     # Pre-delete hook controller cleanup was introduced in Kubewarden 1.37.
-    # Check the version while the chart is still installed and remember the
-    # decision, since later tests run after the uninstall.
+    # Remember the skip-version decision, since later tests run after the
+    # uninstall and cannot check it anymore.
     if helm status -n "$NAMESPACE" admission-controller &>/dev/null; then
         kw_version ">=1.37" || touch "$BATS_FILE_TMPDIR/.skip-version"
+        wait_pods -n "$NAMESPACE"
     fi
     [ ! -f "$BATS_FILE_TMPDIR/.skip-version" ] || skip "Requires admission-controller >= 1.37.0"
 }
@@ -41,20 +51,37 @@ PS_NAME=e2e-uninstall
 POLICY_NAME=safe-labels-for-pods
 
 # add_test_finalizer <kind> <name> [-n namespace]
+# Idempotent: does nothing if the finalizer is already set (the API server
+# rejects duplicate finalizers).
+# Also works when the resource has no finalizers array yet
+# (a JSON-patch "add /metadata/finalizers/-" would fail on those).
 add_test_finalizer() {
-    kubectl patch "$1" "$2" "${@:3}" --type=json \
-        -p "[{\"op\":\"add\",\"path\":\"/metadata/finalizers/-\",\"value\":\"$TEST_FINALIZER\"}]"
-}
-
-# release_test_finalizer <kind> <name> [-n namespace]
-release_test_finalizer() {
     local finalizers
     finalizers=$(kubectl get "$1" "$2" "${@:3}" -o json |
-        jq -c --arg f "$TEST_FINALIZER" '.metadata.finalizers // [] | map(select(. != $f))')
+        jq -ce --arg f "$TEST_FINALIZER" '(.metadata.finalizers // []) + [$f] | unique')
     kubectl patch "$1" "$2" "${@:3}" --type=merge -p "{\"metadata\":{\"finalizers\":$finalizers}}"
 }
 
+# release_test_finalizer <kind> <name> [-n namespace]
+# Idempotent: does nothing if the resource is already gone.
+release_test_finalizer() {
+    local json finalizers
+    json=$(kubectl get "$1" "$2" "${@:3}" -o json 2>/dev/null) || return 0
+    finalizers=$(jq -ce --arg f "$TEST_FINALIZER" '.metadata.finalizers // [] | map(select(. != $f))' <<<"$json")
+    kubectl patch "$1" "$2" "${@:3}" --type=merge -p "{\"metadata\":{\"finalizers\":$finalizers}}"
+}
+
+# Skip tests if no installed kubewarden, so the whole file is idempotent and
+# converges on the final audit.
+skip_uninstalled() {
+    helm status -n "$NAMESPACE" admission-controller &>/dev/null || skip "kubewarden is not installed"
+}
+
+# bats test_tags=setup:--no-wait
 @test "$(tfile) Prepare user resources with test finalizers" {
+    # test requires an installed kubewarden
+    skip_uninstalled
+
     # User-defined PolicyServer with a policy assigned to it
     create_policyserver $PS_NAME
     apply_policy_for_ps $PS_NAME safe-labels-pods-policy.yaml
@@ -77,6 +104,9 @@ release_test_finalizer() {
 
 # bats test_tags=setup:--no-wait
 @test "$(tfile) Uninstall runs the pre-delete hook cleanup" {
+    # test requires an installed kubewarden
+    skip_uninstalled
+
     helmer uninstall
 
     # The pre-delete Job is removed on success (hook-delete-policy: hook-succeeded)
@@ -117,20 +147,24 @@ release_test_finalizer() {
     # All other resources backing the user policy-server are swept
     run kubectl get deployment,service,secret,pdb -n "$NAMESPACE" -l kubewarden/policy-server=$PS_NAME
     assert_output -p "No resources found"
+
+    # The uninstall is only complete once the deleted pods finish their
+    # termination grace period; the leftover audit relies on this
+    kubectl wait --for=delete --timeout=60s pods -A -l app.kubernetes.io/part-of=kubewarden
 }
 
 # bats test_tags=setup:--no-wait
 @test "$(tfile) Escape hatch: resources are deletable once finalizers are released" {
     # Releasing the test finalizer completes the ConfigMap deletion issued
-    # by the cleanup
+    # by the cleanup (already-gone means success, so this is re-run safe).
     release_test_finalizer configmap policy-server-$PS_NAME -n "$NAMESPACE"
     kubectl wait --for=delete --timeout=30s configmap policy-server-$PS_NAME -n "$NAMESPACE"
 
     release_test_finalizer ps $PS_NAME
 
     # Without a running controller, plain kubectl delete must complete on its own
-    kubectl delete --timeout=30s cap $POLICY_NAME
-    kubectl delete --timeout=30s ps $PS_NAME
+    kubectl delete --ignore-not-found --timeout=30s cap $POLICY_NAME
+    kubectl delete --ignore-not-found --timeout=30s ps $PS_NAME
 }
 
 # bats test_tags=setup:--no-wait
@@ -139,11 +173,15 @@ release_test_finalizer() {
     run helm list -n "$NAMESPACE" -q
     assert_output ""
 
-    # No Kubewarden custom resources are left anywhere: the previous
-    # testcases removed the intentionally kept user CRs, and every other CR
-    # created by the test suite or the charts must be gone
-    run kubectl get ps,ap,cap,apg,capg -A
-    assert_output -p "No resources found"
+    # No Kubewarden CRs are left: the previous testcases removed the
+    # intentionally kept user CRs, and every other CR created by the test
+    # suite or the charts must be gone.
+    # On a re-run the CRDs were already removed below, and no CRs can exist
+    # without them.
+    if kubectl get crds policyservers.policies.kubewarden.io &>/dev/null; then
+        run kubectl get ps,ap,cap,apg,capg -A
+        assert_output -p "No resources found"
+    fi
 
     # Nothing labeled as part of Kubewarden survived, namespaced...
     run kubectl get all,jobs,secrets,configmaps,pdb,serviceaccounts,leases -A -l app.kubernetes.io/part-of=kubewarden

--- a/tests/uninstall-tests.bats
+++ b/tests/uninstall-tests.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+
+# Tests for the pre-delete-hook of the admission-controller uninstall
+# that runs the controller image in cleanup mode.
+# These tests also double as testsuite cleanup step, deleting CRs and CRDs at
+# the end.
+#
+# The uninstall must leave behind ONLY the Kubewarden CRDs and the
+# user-defined PolicyServer/policy CRs (with the Kubewarden finalizers
+# stripped), so a future re-installation can adopt and reconcile them again.
+# Everything that makes the policies run (policy-server Deployments, Services,
+# certificate Secrets, ConfigMaps, PodDisruptionBudgets and the webhook
+# configurations) must be removed.
+#
+# For that, we add a test Finalizer that simulates third-party tooling: the
+# cleanup must keep it in place and must not hang waiting on resources it does
+# not own (the deletion is issued and the cleanup moves on). The finalizer is
+# released again by the escape hatch testcase, and the final testcase fails if
+# ANY Kubewarden resource (other than the CRDs) is still around. This file thus
+# doubles as the suite cleanup: run it last, there is no separate teardown to
+# reinstall or to sweep leftovers, so incomplete cleanup cannot be masked.
+#
+# As a cleanup step, the testcase is idempotent: on a re-run against an already
+# uninstalled cluster the install-dependent tests skip, the escape hatch
+# no-ops, and the final leftover audit re-runs and enforces the clean state.
+
+setup() {
+    setup_helper
+
+    # Pre-delete hook controller cleanup was introduced in Kubewarden 1.37.
+    # Check the version while the chart is still installed and remember the
+    # decision, since later tests run after the uninstall.
+    if helm status -n "$NAMESPACE" admission-controller &>/dev/null; then
+        kw_version ">=1.37" || touch "$BATS_FILE_TMPDIR/.skip-version"
+    fi
+    [ ! -f "$BATS_FILE_TMPDIR/.skip-version" ] || skip "Requires admission-controller >= 1.37.0"
+}
+
+TEST_FINALIZER=e2e.kubewarden.io/test-finalizer
+PS_NAME=e2e-uninstall
+POLICY_NAME=safe-labels-for-pods
+
+# add_test_finalizer <kind> <name> [-n namespace]
+add_test_finalizer() {
+    kubectl patch "$1" "$2" "${@:3}" --type=json \
+        -p "[{\"op\":\"add\",\"path\":\"/metadata/finalizers/-\",\"value\":\"$TEST_FINALIZER\"}]"
+}
+
+# release_test_finalizer <kind> <name> [-n namespace]
+release_test_finalizer() {
+    local finalizers
+    finalizers=$(kubectl get "$1" "$2" "${@:3}" -o json |
+        jq -c --arg f "$TEST_FINALIZER" '.metadata.finalizers // [] | map(select(. != $f))')
+    kubectl patch "$1" "$2" "${@:3}" --type=merge -p "{\"metadata\":{\"finalizers\":$finalizers}}"
+}
+
+@test "$(tfile) Prepare user resources with test finalizers" {
+    # User-defined PolicyServer with a policy assigned to it
+    create_policyserver $PS_NAME
+    apply_policy_for_ps $PS_NAME safe-labels-pods-policy.yaml
+
+    # Sanity: both CRs carry the Kubewarden finalizer
+    kubectl get ps $PS_NAME -o json | jq -e '.metadata.finalizers | any(startswith("kubewarden"))'
+    kubectl get cap $POLICY_NAME -o json | jq -e '.metadata.finalizers | any(startswith("kubewarden"))'
+
+    # Sanity: resources backing the user policy-server exist
+    kubectl get deployment,service,secret,configmap,pdb -n "$NAMESPACE" -l kubewarden/policy-server=$PS_NAME
+
+    # Simulate third-party tooling: the cleanup must keep this finalizer on
+    # the user CR while stripping the Kubewarden ones
+    add_test_finalizer ps $PS_NAME
+
+    # and must not hang on a policy-server resource it cannot fully
+    # delete: the deletion is issued and the cleanup moves on
+    add_test_finalizer configmap policy-server-$PS_NAME -n "$NAMESPACE"
+}
+
+# bats test_tags=setup:--no-wait
+@test "$(tfile) Uninstall runs the pre-delete hook cleanup" {
+    helmer uninstall
+
+    # The pre-delete Job is removed on success (hook-delete-policy: hook-succeeded)
+    run kubectl get jobs -n "$NAMESPACE"
+    refute_output -p controller
+
+    # Controller and all policy-server deployments are gone
+    run kubectl get deployments -n "$NAMESPACE"
+    refute_output -p controller
+    refute_output -p policy-server
+
+    # No Kubewarden webhook configurations are left behind (orphaned webhooks
+    # without a policy-server would DoS the cluster)
+    run kubectl get validatingwebhookconfigurations,mutatingwebhookconfigurations -l app.kubernetes.io/part-of=kubewarden
+    assert_output -p "No resources found"
+
+    # CRDs are kept (helm.sh/resource-policy: keep)
+    kubectl get crds policyservers.policies.kubewarden.io
+    kubectl get crds clusteradmissionpolicies.policies.kubewarden.io
+
+    # User CRs are kept: Kubewarden finalizers stripped, test finalizer kept
+    kubectl get ps $PS_NAME -o json | jq -e --arg f "$TEST_FINALIZER" '.metadata.finalizers == [$f]'
+    kubectl get cap $POLICY_NAME -o json | jq -e '.metadata.finalizers // [] | length == 0'
+
+    # The user CRs must not be terminating: they are kept for re-installation
+    kubectl get ps $PS_NAME -o json | jq -e '.metadata.deletionTimestamp == null'
+    kubectl get cap $POLICY_NAME -o json | jq -e '.metadata.deletionTimestamp == null'
+
+    # Chart-managed default CRs (default PolicyServer, recommended policies) are gone
+    run kubectl get ps,cap,capg,ap,apg -A -l kubewarden.io/managed-by=kubewarden-controller-defaults
+    assert_output -p "No resources found"
+
+    # The policy-server ConfigMap held by the test finalizer: the deletion
+    # was issued (terminating) but the cleanup did not wait for it
+    kubectl get configmap policy-server-$PS_NAME -n "$NAMESPACE" -o json |
+        jq -e '.metadata.deletionTimestamp != null'
+
+    # All other resources backing the user policy-server are swept
+    run kubectl get deployment,service,secret,pdb -n "$NAMESPACE" -l kubewarden/policy-server=$PS_NAME
+    assert_output -p "No resources found"
+}
+
+# bats test_tags=setup:--no-wait
+@test "$(tfile) Escape hatch: resources are deletable once finalizers are released" {
+    # Releasing the test finalizer completes the ConfigMap deletion issued
+    # by the cleanup
+    release_test_finalizer configmap policy-server-$PS_NAME -n "$NAMESPACE"
+    kubectl wait --for=delete --timeout=30s configmap policy-server-$PS_NAME -n "$NAMESPACE"
+
+    release_test_finalizer ps $PS_NAME
+
+    # Without a running controller, plain kubectl delete must complete on its own
+    kubectl delete --timeout=30s cap $POLICY_NAME
+    kubectl delete --timeout=30s ps $PS_NAME
+}
+
+# bats test_tags=setup:--no-wait
+@test "$(tfile) Nothing is left over after the uninstall" {
+    # No Helm releases are left in the namespace
+    run helm list -n "$NAMESPACE" -q
+    assert_output ""
+
+    # No Kubewarden custom resources are left anywhere: the previous
+    # testcases removed the intentionally kept user CRs, and every other CR
+    # created by the test suite or the charts must be gone
+    run kubectl get ps,ap,cap,apg,capg -A
+    assert_output -p "No resources found"
+
+    # Nothing labeled as part of Kubewarden survived, namespaced...
+    run kubectl get all,jobs,secrets,configmaps,pdb,serviceaccounts,leases -A -l app.kubernetes.io/part-of=kubewarden
+    assert_output -p "No resources found"
+
+    # ...or cluster-scoped
+    run kubectl get validatingwebhookconfigurations,mutatingwebhookconfigurations,clusterroles,clusterrolebindings -l app.kubernetes.io/part-of=kubewarden
+    assert_output -p "No resources found"
+
+    # No policy-server backing resources survived
+    run kubectl get all,secrets,configmaps,pdb -A -l app.kubernetes.io/component=policy-server
+    assert_output -p "No resources found"
+
+    # Only the CRDs remain, kept on purpose for re-installation.
+    local crds
+    crds=$(kubectl get crds -o name | grep '\.kubewarden\.io$' || true)
+    [ -z "$crds" ] || [ "$(wc -l <<<"$crds")" -eq 5 ] # the 5 policies CRDs, nothing else
+
+    # Remove CRDs and CRs for a complete cleanup
+    [ -z "$crds" ] || kubectl delete --timeout=60s $crds
+
+    # Nothing Kubewarden-related is left in the cluster
+    run kubectl get crds -o name
+    refute_output -p kubewarden.io
+}


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

Fix https://github.com/rancher/kubewarden/issues/69. Implementation of the proposal in https://github.com/kubewarden/kubewarden-end-to-end-tests/pull/326#pullrequestreview-4753839213.

Add a new uninstall-tests.bats, that:
- Always runs as part of `tests` and doesn't get filtered away.
- It tests that the `controller --cleanup` pre-delete-hook did a correct cleanup. This means the hook Job succeeded:
  - No remaining Helm release in the namespace
  - No Kubewarden CR (ps,ap,cap,apg,capg -A)
  - Nothing labeled part-of=kubewarden, namespaced or cluster-scoped (workloads, secrets, configmaps, PDBs, SAs, leases, webhooks, RBAC)
  - Nothing labeled component=policy-server
  - The 5 *.kubewarden.io CRDs remain
  - User managed CRs remain
-  It does this by adding a user-managed policy and PolicyServer, and by adding a test Finalizer to some resources.
- It doubles as a full testsuite cleanup step, it ensures no resource, CRD, or helm chart is left. Until now, we only had the `teardown_helper()`, but that deleted things blindly without verifying, and served as isolation between testcase files.
- It is idempotent, can be run several times.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->

Tested this as a full e2e tests run (` make clean cluster install tests`). Also tested idempotency on several points.
As an example, `make install uninstall-tests.bats` followed by `make uninstall-tests.bats`: 

<details>

<summary>Click here</summary>

```shell
$ make install uninstall-tests.bats
./scripts/helmer.sh install
Install next: (app:v1.37.0 controller:6.0.0)
helm_up admission-controller kubewarden/admission-controller --version 6.0.0
Release "admission-controller" does not exist. Installing it now.
(...)
Running BATS tests: uninstall-tests.bats
uninstall-tests.bats
 ✓ [uninstall-tests.bats] Prepare user resources with test finalizers [54282]
 ✓ [uninstall-tests.bats] Uninstall runs the pre-delete hook cleanup [33511]
 ✓ [uninstall-tests.bats] Escape hatch: resources are deletable once finalizers are released [299]
 ✓ [uninstall-tests.bats] Nothing is left over after the uninstall [1262]

4 tests, 0 failures in 90 seconds

$ make uninstall-tests.bats
Running BATS tests: uninstall-tests.bats
uninstall-tests.bats
 - [uninstall-tests.bats] Prepare user resources with test finalizers (skipped: kubewarden is not installed) [76]
 - [uninstall-tests.bats] Uninstall runs the pre-delete hook cleanup (skipped: kubewarden is not installed) [71]
 ✓ [uninstall-tests.bats] Escape hatch: resources are deletable once finalizers are released [211]
 ✓ [uninstall-tests.bats] Nothing is left over after the uninstall [1056]

4 tests, 0 failures, 2 skipped in 2 seconds


```
</details>


## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
